### PR TITLE
Nix build: add flake.

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,50 +1,15 @@
 {
   haskellCompiler ? "ghc865",
   profile ? false,
-  src ? builtins.fetchGit ./.
+  src ? builtins.fetchGit ./.,
+  system ? builtins.currentSystem,
+  tools ? import ./nix/tools.nix { inherit system; }
 }:
 let
-  tools = import ./nix/tools.nix;
   pkgs = tools.pkgs; # TODO is this correct?
   lib = tools.pkgs.lib;
-  hsPkgs =
-  (tools.pkgs.haskell-nix.cabalProject {
-    inherit src;
-    name = "morpho-checkpoint-node";
-    compiler-nix-name = haskellCompiler;
-    pkg-def-extras = [
-      (hackage: {
-        packages = {
-          "quiet" = (((hackage.quiet)."0.2").revisions).default;
-        };})
-    ];
-    modules = [
-    #   # Specific package overrides would go here for example:
-    #   packages.cbors.package.ghcOptions = "-Werror";
-    #   packages.cbors.patches = [ ./one.patch ];
-    #   packages.cbors.flags.optimize-gmp = false;
-    (lib.recursiveUpdate {
-      # Some pkgs fail to build haddock documentation
-      packages.bytestring-builder.doHaddock = false;
-      packages.fail.doHaddock = false;
-      packages.mtl-compat.doHaddock = false;
-      packages.dns.doHaddock = false;
-      packages.matrix.doHaddock = false;
-      packages.terminfo.doHaddock = false;
-    }  (lib.optionalAttrs profile {
-      enableLibraryProfiling = true;
-      packages.morpho-checkpoint-node.enableExecutableProfiling = true;
-    }))
-    #   # It may be better to set flags in `cabal.project` instead
-    #   # (`plan-to-nix` will include them as defaults).
-    ];
-    pkgs = [
-      "canonical-json"
-    ];
-    extra-hackages = [
-    ];
-  });
-  shell = hsPkgs.shellFor {
+  morphoPkgs = import ./nix/morpho-node.nix { inherit pkgs src haskellCompiler profile; };
+  shell = morphoPkgs.shellFor {
     packages = ps: with ps; [
       morpho-checkpoint-node
     ];
@@ -68,4 +33,4 @@ let
     #exactDeps = false;
   };
   # Instantiate a package set using the generated file.
-in hsPkgs // { inherit shell pkgs; }
+in morphoPkgs // { inherit shell pkgs; }

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,46 @@
+{
+  "nodes": {
+    "haskell-nix": {
+      "locked": {
+        "lastModified": 1604670513,
+        "narHash": "sha256-ir7WUoKjN/RUm7xk73K1GKUREui7pXWWgIHYTrqSxPs=",
+        "owner": "input-output-hk",
+        "repo": "haskell.nix",
+        "rev": "ddc4d650fe668c84090ccc9e3ad6a5b82c6654f7",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "ref": "update-flake",
+        "repo": "haskell.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "haskell-nix": "haskell-nix",
+        "nixpkgs": [
+          "haskell-nix"
+        ],
+        "utils": "utils"
+      }
+    },
+    "utils": {
+      "locked": {
+        "lastModified": 1601282935,
+        "narHash": "sha256-WQAFV6sGGQxrRs3a+/Yj9xUYvhTpukQJIcMbIi7LCJ4=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "588973065fce51f4763287f0fda87a174d78bf48",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,21 @@
+{
+  description = "Morpho checkpointing node";
+
+  inputs = {
+    haskell-nix.url = "github:input-output-hk/haskell.nix/update-flake";
+    nixpkgs.follows = "haskell-nix";
+    utils.url = "github:numtide/flake-utils";
+  };
+
+  outputs = { self, nixpkgs, utils, haskell-nix, ... }: (utils.lib.eachSystem [ "x86_64-linux" "x86_64-darwin" ]
+    (system: rec {
+      morpho-pkgs = import ./nix/morpho-node.nix {
+        pkgs = (import haskell-nix.sources.nixpkgs (haskell-nix.nixpkgsArgs // { inherit system; })).pkgs;
+        src = ./.;
+        profile = false;
+        haskellCompiler = "ghc865";
+      };
+      morpho-node = morpho-pkgs.morpho-checkpoint-node.components.exes.morpho-checkpoint-node;
+      defaultPackage = morpho-node;
+    }));
+}

--- a/nix/morpho-node.nix
+++ b/nix/morpho-node.nix
@@ -1,0 +1,46 @@
+{ pkgs
+, src
+, haskellCompiler ? "ghc865"
+, profile
+, ...
+}:
+
+pkgs.haskell-nix.cabalProject {
+  inherit src;
+  name = "morpho-checkpoint-node";
+  compiler-nix-name = haskellCompiler;
+  pkg-def-extras = [
+    (hackage: {
+      packages = {
+        "quiet" = (((hackage.quiet)."0.2").revisions).default;
+      };
+    })
+  ];
+  modules = [
+    #   # Specific package overrides would go here for example:
+    #   packages.cbors.package.ghcOptions = "-Werror";
+    #   packages.cbors.patches = [ ./one.patch ];
+    #   packages.cbors.flags.optimize-gmp = false;
+    (pkgs.lib.recursiveUpdate
+      {
+        # Some pkgs fail to build haddock documentation
+        packages.bytestring-builder.doHaddock = false;
+        packages.fail.doHaddock = false;
+        packages.mtl-compat.doHaddock = false;
+        packages.dns.doHaddock = false;
+        packages.matrix.doHaddock = false;
+        packages.terminfo.doHaddock = false;
+      }
+      (pkgs.lib.optionalAttrs profile {
+        enableLibraryProfiling = true;
+        packages.morpho-checkpoint-node.enableExecutableProfiling = true;
+      }))
+    #   # It may be better to set flags in `cabal.project` instead
+    #   # (`plan-to-nix` will include them as defaults).
+  ];
+  pkgs = [
+    "canonical-json"
+  ];
+  extra-hackages = [
+  ];
+}

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -5,10 +5,10 @@
         "homepage": "https://input-output-hk.github.io/haskell.nix",
         "owner": "input-output-hk",
         "repo": "haskell.nix",
-        "rev": "a1b6975e57d7d49f79daa7c190d964e86d01a30e",
-        "sha256": "1yn4c745ac0b5fhmj993hwwmymwayrskj68xgnrzikqgdn3273k3",
+        "rev": "8c0b7c27b4806340ffe8e3f163b2cd06e062a6fb",
+        "sha256": "1dadlbi1sgzl1v2k7g8iwpiyiigb9xslvyh0idpadgjdv04ndv0c",
         "type": "tarball",
-        "url": "https://github.com/input-output-hk/haskell.nix/archive/a1b6975e57d7d49f79daa7c190d964e86d01a30e.tar.gz",
+        "url": "https://github.com/input-output-hk/haskell.nix/archive/8c0b7c27b4806340ffe8e3f163b2cd06e062a6fb.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "niv": {

--- a/nix/sources.nix
+++ b/nix/sources.nix
@@ -6,82 +6,99 @@ let
   # The fetchers. fetch_<type> fetches specs of type <type>.
   #
 
-  fetch_file = pkgs: spec:
-    if spec.builtin or true then
-      builtins_fetchurl { inherit (spec) url sha256; }
-    else
-      pkgs.fetchurl { inherit (spec) url sha256; };
+  fetch_file = pkgs: name: spec:
+    let
+      name' = sanitizeName name + "-src";
+    in
+      if spec.builtin or true then
+        builtins_fetchurl { inherit (spec) url sha256; name = name'; }
+      else
+        pkgs.fetchurl { inherit (spec) url sha256; name = name'; };
 
-  fetch_tarball = pkgs: spec:
-    if spec.builtin or true then
-      builtins_fetchTarball { inherit (spec) url sha256; }
-    else
-      pkgs.fetchzip { inherit (spec) url sha256; };
+  fetch_tarball = pkgs: name: spec:
+    let
+      name' = sanitizeName name + "-src";
+    in
+      if spec.builtin or true then
+        builtins_fetchTarball { name = name'; inherit (spec) url sha256; }
+      else
+        pkgs.fetchzip { name = name'; inherit (spec) url sha256; };
 
-  fetch_git = spec:
-      builtins.fetchGit { url = spec.repo; inherit (spec) rev ref; };
+  fetch_git = name: spec:
+    let
+      ref =
+        if spec ? ref then spec.ref else
+          if spec ? branch then "refs/heads/${spec.branch}" else
+            if spec ? tag then "refs/tags/${spec.tag}" else
+              abort "In git source '${name}': Please specify `ref`, `tag` or `branch`!";
+    in
+      builtins.fetchGit { url = spec.repo; inherit (spec) rev; inherit ref; };
 
-  fetch_builtin-tarball = spec:
-    builtins.trace
-      ''
-        WARNING:
-          The niv type "builtin-tarball" will soon be deprecated. You should
-          instead use `builtin = true`.
+  fetch_local = spec: spec.path;
 
-          $ niv modify <package> -a type=tarball -a builtin=true
-      ''
-      builtins_fetchTarball { inherit (spec) url sha256; };
+  fetch_builtin-tarball = name: throw
+    ''[${name}] The niv type "builtin-tarball" is deprecated. You should instead use `builtin = true`.
+        $ niv modify ${name} -a type=tarball -a builtin=true'';
 
-  fetch_builtin-url = spec:
-    builtins.trace
-      ''
-        WARNING:
-          The niv type "builtin-url" will soon be deprecated. You should
-          instead use `builtin = true`.
-
-          $ niv modify <package> -a type=file -a builtin=true
-      ''
-      (builtins_fetchurl { inherit (spec) url sha256; });
+  fetch_builtin-url = name: throw
+    ''[${name}] The niv type "builtin-url" will soon be deprecated. You should instead use `builtin = true`.
+        $ niv modify ${name} -a type=file -a builtin=true'';
 
   #
   # Various helpers
   #
 
+  # https://github.com/NixOS/nixpkgs/pull/83241/files#diff-c6f540a4f3bfa4b0e8b6bafd4cd54e8bR695
+  sanitizeName = name:
+    (
+      concatMapStrings (s: if builtins.isList s then "-" else s)
+        (
+          builtins.split "[^[:alnum:]+._?=-]+"
+            ((x: builtins.elemAt (builtins.match "\\.*(.*)" x) 0) name)
+        )
+    );
+
   # The set of packages used when specs are fetched using non-builtins.
-  mkPkgs = sources:
-    if hasNixpkgsPath
-    then
-      if hasThisAsNixpkgsPath
-      then import (builtins_fetchTarball { inherit (mkNixpkgs sources) url sha256; }) {}
-      else import <nixpkgs> {}
-    else
-      import (builtins_fetchTarball { inherit (mkNixpkgs sources) url sha256; }) {};
-
-  mkNixpkgs = sources:
-    if builtins.hasAttr "nixpkgs" sources
-    then sources.nixpkgs
-    else abort
-      ''
-        Please specify either <nixpkgs> (through -I or NIX_PATH=nixpkgs=...) or
-        add a package called "nixpkgs" to your sources.json.
-      '';
-
-  hasNixpkgsPath = (builtins.tryEval <nixpkgs>).success;
-  hasThisAsNixpkgsPath =
-    (builtins.tryEval <nixpkgs>).success && <nixpkgs> == ./.;
+  mkPkgs = sources: system:
+    let
+      sourcesNixpkgs =
+        import (builtins_fetchTarball { inherit (sources.nixpkgs) url sha256; }) { inherit system; };
+      hasNixpkgsPath = builtins.any (x: x.prefix == "nixpkgs") builtins.nixPath;
+      hasThisAsNixpkgsPath = <nixpkgs> == ./.;
+    in
+      if builtins.hasAttr "nixpkgs" sources
+      then sourcesNixpkgs
+      else if hasNixpkgsPath && ! hasThisAsNixpkgsPath then
+        import <nixpkgs> {}
+      else
+        abort
+          ''
+            Please specify either <nixpkgs> (through -I or NIX_PATH=nixpkgs=...) or
+            add a package called "nixpkgs" to your sources.json.
+          '';
 
   # The actual fetching function.
   fetch = pkgs: name: spec:
 
     if ! builtins.hasAttr "type" spec then
       abort "ERROR: niv spec ${name} does not have a 'type' attribute"
-    else if spec.type == "file" then fetch_file pkgs spec
-    else if spec.type == "tarball" then fetch_tarball pkgs spec
-    else if spec.type == "git" then fetch_git spec
-    else if spec.type == "builtin-tarball" then fetch_builtin-tarball spec
-    else if spec.type == "builtin-url" then fetch_builtin-url spec
+    else if spec.type == "file" then fetch_file pkgs name spec
+    else if spec.type == "tarball" then fetch_tarball pkgs name spec
+    else if spec.type == "git" then fetch_git name spec
+    else if spec.type == "local" then fetch_local spec
+    else if spec.type == "builtin-tarball" then fetch_builtin-tarball name
+    else if spec.type == "builtin-url" then fetch_builtin-url name
     else
       abort "ERROR: niv spec ${name} has unknown type ${builtins.toJSON spec.type}";
+
+  # If the environment variable NIV_OVERRIDE_${name} is set, then use
+  # the path directly as opposed to the fetched source.
+  replace = name: drv:
+    let
+      saneName = stringAsChars (c: if isNull (builtins.match "[a-zA-Z0-9]" c) then "_" else c) name;
+      ersatz = builtins.getEnv "NIV_OVERRIDE_${saneName}";
+    in
+      if ersatz == "" then drv else ersatz;
 
   # Ports of functions for older nix versions
 
@@ -91,23 +108,37 @@ let
     listToAttrs (map (attr: { name = attr; value = f attr set.${attr}; }) (attrNames set))
   );
 
+  # https://github.com/NixOS/nixpkgs/blob/0258808f5744ca980b9a1f24fe0b1e6f0fecee9c/lib/lists.nix#L295
+  range = first: last: if first > last then [] else builtins.genList (n: first + n) (last - first + 1);
+
+  # https://github.com/NixOS/nixpkgs/blob/0258808f5744ca980b9a1f24fe0b1e6f0fecee9c/lib/strings.nix#L257
+  stringToCharacters = s: map (p: builtins.substring p 1 s) (range 0 (builtins.stringLength s - 1));
+
+  # https://github.com/NixOS/nixpkgs/blob/0258808f5744ca980b9a1f24fe0b1e6f0fecee9c/lib/strings.nix#L269
+  stringAsChars = f: s: concatStrings (map f (stringToCharacters s));
+  concatMapStrings = f: list: concatStrings (map f list);
+  concatStrings = builtins.concatStringsSep "";
+
+  # https://github.com/NixOS/nixpkgs/blob/8a9f58a375c401b96da862d969f66429def1d118/lib/attrsets.nix#L331
+  optionalAttrs = cond: as: if cond then as else {};
+
   # fetchTarball version that is compatible between all the versions of Nix
-  builtins_fetchTarball = { url, sha256 }@attrs:
+  builtins_fetchTarball = { url, name ? null, sha256 }@attrs:
     let
       inherit (builtins) lessThan nixVersion fetchTarball;
     in
       if lessThan nixVersion "1.12" then
-        fetchTarball { inherit url; }
+        fetchTarball ({ inherit url; } // (optionalAttrs (!isNull name) { inherit name; }))
       else
         fetchTarball attrs;
 
   # fetchurl version that is compatible between all the versions of Nix
-  builtins_fetchurl = { url, sha256 }@attrs:
+  builtins_fetchurl = { url, name ? null, sha256 }@attrs:
     let
       inherit (builtins) lessThan nixVersion fetchurl;
     in
       if lessThan nixVersion "1.12" then
-        fetchurl { inherit url; }
+        fetchurl ({ inherit url; } // (optionalAttrs (!isNull name) { inherit name; }))
       else
         fetchurl attrs;
 
@@ -119,18 +150,22 @@ let
         then abort
           "The values in sources.json should not have an 'outPath' attribute"
         else
-          spec // { outPath = fetch config.pkgs name spec; }
+          spec // { outPath = replace name (fetch config.pkgs name spec); }
     ) config.sources;
 
   # The "config" used by the fetchers
   mkConfig =
-    { sourcesFile ? ./sources.json
+    { sourcesFile ? if builtins.pathExists ./sources.json then ./sources.json else null
+    , sources ? if isNull sourcesFile then {} else builtins.fromJSON (builtins.readFile sourcesFile)
+    , system ? builtins.currentSystem
+    , pkgs ? mkPkgs sources system
     }: rec {
       # The sources, i.e. the attribute set of spec name to spec
-      sources = builtins.fromJSON (builtins.readFile sourcesFile);
+      inherit sources;
+
       # The "pkgs" (evaluated nixpkgs) to use for e.g. non-builtin fetchers
-      pkgs = mkPkgs sources;
+      inherit pkgs;
     };
+
 in
-mkSources (mkConfig {}) //
-  { __functor = _: settings: mkSources (mkConfig settings); }
+mkSources (mkConfig {}) // { __functor = _: settings: mkSources (mkConfig settings); }

--- a/nix/tools.nix
+++ b/nix/tools.nix
@@ -1,10 +1,12 @@
+{ system ? builtins.currentSystem }:
 let
   sources = import ./sources.nix;
-  haskell-nix = import sources."haskell.nix" {};
+  haskell-nix = import sources."haskell.nix" { inherit system; };
   nixpkgs = haskell-nix.sources.nixpkgs-2003;
   pkgs = (import nixpkgs haskell-nix.nixpkgsArgs).pkgs;
 in {
-  inherit nixpkgs haskell-nix pkgs;
+  inherit haskell-nix pkgs;
+  nixpkgs = nixpkgs { inherit system; };
   niv = (import sources.niv {}).niv;
   nix-tools = pkgs.haskell-nix.nix-tools;
 }


### PR DESCRIPTION
We need a flake-compatible build to deploy the checkpoint node with
bitte.

We're extracting the `haskell.nix`-specific part to a new
`morpho-node` file and re-use this haskell build for both the
"regular" nix-build systemd and the nix flake build system.