### PR TITLE
ECDSA Signing: fix bug and add Mantis integration tests

### DIFF
--- a/README.org
+++ b/README.org
@@ -50,6 +50,48 @@ To build =morpho-checkpoint-node=, run
 » nix build -f . morpho-checkpoint-node.components.exes.morpho-checkpoint-node
 #+end_src
 
+* Test the Project
+
+We currently have three test suites. All these suites are ran by hydra
+on each PR.
+
+** Unit Tests
+   These tests are mostly meant to be run interactively when working
+   on the checkpoint node. They are pretty fast to complete (>5s).
+
+   You can run those using:
+
+   #+BEGIN_SRC
+   cabal test morpho-checkpoint-node:test
+   #+END_SRC
+
+** State Machine Tests
+   These tests are acting as integration tests. They'll require to
+   spin up several morpho nodes and mocked mantis nodes. They are
+   pretty long to run (~4 minutes), hence not really meant to be run
+   very frequently.
+
+   You can run those using:
+
+   #+BEGIN_SRC
+    cabal test morpho-checkpoint-node:state-machine-tests
+   #+END_SRC
+
+** Mantis Integration Tests
+   Here, we are testing some Morpho node features directly against the
+   Mantis node itself. These test require to have Mantis and its
+   associated CLIs (incl. =signatureValidator=) in your =$PATH= when
+   running them.
+
+   The easiest way to add these to your =$PATH= is to enter the nix
+   shell using the =nix-shell= command.
+
+   You can run those using:
+
+   #+BEGIN_SRC
+    cabal test morpho-checkpoint-node:mantis-integration-tests
+   #+END_SRC
+
 * Code Formatting
 
 We are using the =ormolu= formatter for the Haskell files, =cabal

--- a/default.nix
+++ b/default.nix
@@ -12,8 +12,8 @@ let
       fetchSubmodules = true;
       owner = "input-output-hk";
       repo = "mantis";
-      rev = "f4fa32b7589e0bf6044f95ccb6db202cbe039a6c";
-      sha256 = "sha256-h/oVh+xnCzIPOUS+5onGuGmOIOIl4tjVu3wcAWPZcYA=";
+      rev = "6e76301275659f7c096d4ed4ebdc4de36b3c7e4a";
+      sha256 = "sha256-kFLfYQ+8ogz4uycvriAszwP3Af7yqRGrxH6l6HmnKuc=";
     })
     { inherit system; };
   morphoPkgs = import ./nix/morpho-node.nix { inherit pkgs src haskellCompiler profile; };

--- a/default.nix
+++ b/default.nix
@@ -43,4 +43,4 @@ let
   };
   # Instantiate a package set using the generated file.
 in
-morphoPkgs // { inherit shell pkgs; }
+morphoPkgs // { inherit shell pkgs mantis; }

--- a/default.nix
+++ b/default.nix
@@ -1,13 +1,21 @@
-{
-  haskellCompiler ? "ghc865",
-  profile ? false,
-  src ? builtins.fetchGit ./.,
-  system ? builtins.currentSystem,
-  tools ? import ./nix/tools.nix { inherit system; }
+{ haskellCompiler ? "ghc865"
+, profile ? false
+, src ? builtins.fetchGit ./.
+, system ? builtins.currentSystem
+, tools ? import ./nix/tools.nix { inherit system; }
 }:
 let
-  pkgs = tools.pkgs; # TODO is this correct?
+  pkgs = tools.pkgs;
   lib = tools.pkgs.lib;
+  mantis = import
+    (pkgs.fetchFromGitHub {
+      fetchSubmodules = true;
+      owner = "input-output-hk";
+      repo = "mantis";
+      rev = "f4fa32b7589e0bf6044f95ccb6db202cbe039a6c";
+      sha256 = "sha256-h/oVh+xnCzIPOUS+5onGuGmOIOIl4tjVu3wcAWPZcYA=";
+    })
+    { inherit system; };
   morphoPkgs = import ./nix/morpho-node.nix { inherit pkgs src haskellCompiler profile; };
   shell = morphoPkgs.shellFor {
     packages = ps: with ps; [
@@ -17,20 +25,22 @@ let
     tools = {
       cabal = "3.2.0.0";
     };
-    buildInputs = with tools.pkgs.haskellPackages;
-    [
-      ghcid
-      hlint
-      ormolu
-      pkgs.pkgconfig
-      stylish-haskell
-      tools.niv
-    ] ++
-    # lobemo is depending on libsystemd for the journald bindings.
-    # Systemd won't build on darwin, checking first we're not on a
-    # Darwin env.
-    (pkgs.stdenv.lib.optional (!pkgs.stdenv.isDarwin) pkgs.systemd);
+    buildInputs = with pkgs.haskellPackages;
+      [
+        ghcid
+        hlint
+        ormolu
+        pkgs.pkgconfig
+        stylish-haskell
+        tools.niv
+        mantis
+      ] ++
+      # lobemo is depending on libsystemd for the journald bindings.
+      # Systemd won't build on darwin, checking first we're not on a
+      # Darwin env.
+      (pkgs.stdenv.lib.optional (!pkgs.stdenv.isDarwin) pkgs.systemd);
     #exactDeps = false;
   };
   # Instantiate a package set using the generated file.
-in morphoPkgs // { inherit shell pkgs; }
+in
+morphoPkgs // { inherit shell pkgs; }

--- a/morpho-checkpoint-node/morpho-checkpoint-node.cabal
+++ b/morpho-checkpoint-node/morpho-checkpoint-node.cabal
@@ -146,6 +146,7 @@ test-suite test
         Test.Morpho.Generators
         Test.Morpho.Golden
         Test.Morpho.QSM
+        Test.Morpho.MantisIntegration
         Test.Morpho.Serialisation
 
     default-language:   Haskell2010
@@ -171,6 +172,7 @@ test-suite test
         morpho-checkpoint-node -any,
         ouroboros-network -any,
         ouroboros-consensus -any,
+        process -any,
         ouroboros-consensus-test-infra -any,
         text -any,
         QuickCheck -any,

--- a/morpho-checkpoint-node/morpho-checkpoint-node.cabal
+++ b/morpho-checkpoint-node/morpho-checkpoint-node.cabal
@@ -60,7 +60,6 @@ library
         cborg -any,
         containers -any,
         contra-tracer -any,
-        cryptonite -any,
         directory -any,
         filepath -any,
         hashable -any,
@@ -113,7 +112,6 @@ executable morpho-checkpoint-node
         cborg >=0.2.2 && <0.3,
         containers -any,
         contra-tracer -any,
-        cryptonite -any,
         directory -any,
         ekg-prometheus-adapter -any,
         formatting -any,
@@ -145,38 +143,76 @@ test-suite test
         Test.Morpho.Examples
         Test.Morpho.Generators
         Test.Morpho.Golden
-        Test.Morpho.QSM
-        Test.Morpho.MantisIntegration
         Test.Morpho.Serialisation
 
     default-language:   Haskell2010
     default-extensions: NoImplicitPrelude
     build-depends:
         base >=4.12.0.0,
-        async -any,
+        QuickCheck -any,
+        bytestring -any,
+        cardano-crypto-class -any,
+        cardano-crypto-wrapper -any,
+        cardano-prelude -any,
+        cborg -any,
+        containers -any,
+        hspec-core -any,
+        iohk-monitoring -any,
+        morpho-checkpoint-node -any,
+        ouroboros-consensus -any,
+        ouroboros-consensus-test-infra -any,
+        ouroboros-network -any,
+        quickcheck-instances -any,
         serialise -any,
-        tasty >=0.7,
+        tasty -any,
+        tasty-hspec -any,
         tasty-hunit -any,
         tasty-quickcheck -any,
-        tasty-hspec -any,
-        time -any,
-        hspec-core -any,
+        text -any,
+        time -any
+
+test-suite mantis-integration-tests
+    type:               exitcode-stdio-1.0
+    main-is:            mantis-integration-tests.hs
+    hs-source-dirs:     tests
+    other-modules:      Test.Morpho.MantisIntegration
+    default-language:   Haskell2010
+    default-extensions: NoImplicitPrelude
+    build-depends:
+        base >=4.12.0.0,
+        QuickCheck -any,
         bytestring -any,
         cardano-prelude -any,
+        morpho-checkpoint-node -any,
+        process -any,
+        tasty -any,
+        tasty-quickcheck -any,
+        text -any
+
+test-suite state-machine-tests
+    type:               exitcode-stdio-1.0
+    main-is:            state-machine-tests.hs
+    hs-source-dirs:     tests
+    other-modules:
+        Test.Morpho.QSM
+        Test.Morpho.Generators
+
+    default-language:   Haskell2010
+    default-extensions: NoImplicitPrelude
+    build-depends:
+        base >=4.12.0.0,
+        QuickCheck -any,
+        async -any,
+        bytestring -any,
         cardano-crypto-class -any,
-        cardano-crypto-tests -any,
-        cardano-crypto-wrapper -any,
         containers -any,
-        cryptonite -any,
         directory -any,
         morpho-checkpoint-node -any,
-        ouroboros-network -any,
         ouroboros-consensus -any,
-        process -any,
         ouroboros-consensus-test-infra -any,
-        text -any,
-        QuickCheck -any,
+        ouroboros-consensus-test-infra -any,
         quickcheck-instances -any,
         quickcheck-state-machine >=0.7,
-        iohk-monitoring -any,
-        cborg -any
+        tasty -any,
+        tasty-quickcheck -any,
+        text -any

--- a/morpho-checkpoint-node/src/Morpho/Crypto/ECDSASignature.hs
+++ b/morpho-checkpoint-node/src/Morpho/Crypto/ECDSASignature.hs
@@ -12,6 +12,7 @@ module Morpho.Crypto.ECDSASignature
   ( Signature (..),
     sign,
     recoverPublicKey,
+    pubToHex,
     sigToHex,
     importPublicKey,
     importPrivateKey,
@@ -150,3 +151,6 @@ toPublicKey = PublicKey . B.Bytes . BS.tail . EC.exportPubKey False
 
 sigToHex :: Signature -> Text
 sigToHex (Signature r s v) = bytesToHex r <> bytesToHex s <> integerToHex 1 v
+
+pubToHex :: PublicKey -> Text
+pubToHex (PublicKey b) = bytesToHex b

--- a/morpho-checkpoint-node/src/Morpho/Crypto/ECDSASignature.hs
+++ b/morpho-checkpoint-node/src/Morpho/Crypto/ECDSASignature.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE DeriveAnyClass #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
-{-# LANGUAGE StandaloneDeriving #-}
 
 -- | This module implements an ECDSA signature scheme based on SEC_p256k1 curve.
 -- The point is to match the same signature scheme used in the PoW blockchain, which enables public key recovery
@@ -39,12 +38,12 @@ import qualified Morpho.Common.Bytes as B
 import Morpho.Common.Conversions
 import Prelude hiding (fail)
 
-data PublicKey = PublicKey B.Bytes
+newtype PublicKey = PublicKey B.Bytes
   deriving stock (Show, Eq, Generic, Ord)
   deriving anyclass (Serialise)
   deriving (NoUnexpectedThunks)
 
-data PrivateKey = PrivateKey B.Bytes
+newtype PrivateKey = PrivateKey B.Bytes
   deriving stock (Show, Eq, Generic, Ord)
   deriving anyclass (Serialise)
   deriving (NoUnexpectedThunks)
@@ -121,21 +120,21 @@ recSigToSignature :: RecSig -> Signature
 recSigToSignature rs =
   Signature (B.Bytes $ BS.fromShort r) (B.Bytes $ BS.fromShort s) (v + morphoRecIdOffset)
   where
-    CompactRecSig s r v = EC.exportCompactRecSig rs
+    CompactRecSig r s v = EC.exportCompactRecSig rs
 
 recSigFromSignature :: Signature -> Maybe RecSig
 recSigFromSignature sig =
   EC.importCompactRecSig compactRS
   where
     Signature (B.Bytes r) (B.Bytes s) v = sig
-    compactRS = CompactRecSig (BS.toShort s) (BS.toShort r) (v - morphoRecIdOffset)
+    compactRS = CompactRecSig (BS.toShort r) (BS.toShort s) (v - morphoRecIdOffset)
 
 -- | import a 32 or 33 byte long (that is with leading 0) private key
 importPrivateKey :: B.Bytes -> Maybe PrivateKey
 importPrivateKey (B.Bytes bytestr) =
   PrivateKey . B.Bytes . EC.getSecKey <$> EC.secKey adjustedBytestr
   where
-    adjustedBytestr = if (BS.length bytestr > 32) then BS.drop 1 bytestr else bytestr
+    adjustedBytestr = if BS.length bytestr > 32 then BS.drop 1 bytestr else bytestr
 
 -- | import an uncompressed 64 byte long public key (that is without compression indicator byte)
 importPublicKey :: B.Bytes -> Maybe PublicKey

--- a/morpho-checkpoint-node/tests/Test/Morpho/MantisIntegration.hs
+++ b/morpho-checkpoint-node/tests/Test/Morpho/MantisIntegration.hs
@@ -1,0 +1,59 @@
+{-# LANGUAGE OverloadedStrings #-}
+
+module Test.Morpho.MantisIntegration
+  ( mantisIntegrationTests,
+  )
+where
+
+import Cardano.Prelude
+import qualified Data.ByteString as BS
+import Data.Maybe (fromJust)
+import qualified Data.Text as T
+import Morpho.Common.Bytes
+import Morpho.Common.Conversions
+import Morpho.Crypto.ECDSASignature
+import System.Process
+import Test.QuickCheck hiding (reason)
+import Test.QuickCheck.Property
+import Test.Tasty (TestTree, testGroup)
+import Test.Tasty.QuickCheck (testProperty)
+
+mantisIntegrationTests :: TestTree
+mantisIntegrationTests =
+  testGroup
+    "mantis-integration"
+    [testProperty "Test the keygen against the actual Mantis parser" prop_mantisValidSig]
+
+prop_mantisValidSig :: Property
+prop_mantisValidSig =
+  forAll generateKP $ \(KeyPair pk sk) ->
+    forAll generateBytes $ \bytes -> ioProperty $ do
+      let msignature = sign sk bytes
+      r <- mantisValidateKey pk msignature bytes
+      pure $ case r of
+        Nothing -> succeeded
+        Just err -> failed {reason = "Mantis returned a non 0 status: " <> T.unpack err}
+  where
+    mantisValidateKey :: PublicKey -> Maybe Signature -> Bytes -> IO (Maybe Text)
+    mantisValidateKey _ Nothing h = pure . Just $ "Morpho cannot generate the signature for " <> bytesToHex h
+    mantisValidateKey pk (Just s) h = do
+      let hexs = T.unpack $ sigToHex s
+          hexh = T.unpack $ bytesToHex h
+          hexpk = T.unpack $ pubToHex pk
+      (ec, _, err) <- readProcessWithExitCode "signatureValidator" [hexpk, hexs, hexh] ""
+      pure $ case ec of
+        ExitSuccess -> Nothing
+        ExitFailure _ -> Just $ T.pack err
+
+generateKP :: Gen KeyPair
+generateKP =
+  keyPairFromPrivate <$> prvKey
+  where
+    prvKey = fromJust . importPrivateKey . integerToBytes 32 <$> d
+    -- the `n` parameter of secp256k1 curve
+    n = 0xfffffffffffffffffffffffffffffffebaaedce6af48a03bbfd25e8cd0364141 :: Integer
+    d = choose (1, n - 1)
+
+generateBytes :: Gen Bytes
+generateBytes =
+  Bytes . BS.pack <$> vectorOf 32 (choose (0, 255))

--- a/morpho-checkpoint-node/tests/Test/Morpho/MantisIntegration.hs
+++ b/morpho-checkpoint-node/tests/Test/Morpho/MantisIntegration.hs
@@ -18,6 +18,14 @@ import Test.QuickCheck.Property
 import Test.Tasty (TestTree, testGroup)
 import Test.Tasty.QuickCheck (testProperty)
 
+{-
+   Mantis Integration Tests:
+
+   We are running this whole test suite against the actual Mantis
+   implementation. We always consider that Mantis and its associated
+   CLIs are in $PATH when running this test suite.
+-}
+
 mantisIntegrationTests :: TestTree
 mantisIntegrationTests =
   testGroup
@@ -40,6 +48,12 @@ prop_mantisValidSig =
       let hexs = T.unpack $ sigToHex s
           hexh = T.unpack $ bytesToHex h
           hexpk = T.unpack $ pubToHex pk
+      -- Note: signatureValidator is a CLI tool provided by Mantis. It expects as input
+      --       as public key, a signature and the message we just signed.
+      --       If Mantis manages to validate this signature provided
+      --       the pubkey, it'll exit with a 0 code.
+      --       Some useful debugging information is provided to stderr
+      --       in case of validation failure.
       (ec, _, err) <- readProcessWithExitCode "signatureValidator" [hexpk, hexs, hexh] ""
       pure $ case ec of
         ExitSuccess -> Nothing

--- a/morpho-checkpoint-node/tests/mantis-integration-tests.hs
+++ b/morpho-checkpoint-node/tests/mantis-integration-tests.hs
@@ -1,0 +1,14 @@
+import Test.Morpho.MantisIntegration
+import Test.Tasty
+import Prelude
+
+main :: IO ()
+main = tests >>= defaultMain
+
+tests :: IO TestTree
+tests = do
+  return $
+    testGroup
+      "Mantis Integration Tests"
+      [ mantisIntegrationTests
+      ]

--- a/morpho-checkpoint-node/tests/state-machine-tests.hs
+++ b/morpho-checkpoint-node/tests/state-machine-tests.hs
@@ -1,0 +1,14 @@
+import Test.Morpho.QSM
+import Test.Tasty
+import Prelude
+
+main :: IO ()
+main = tests >>= defaultMain
+
+tests :: IO TestTree
+tests = do
+  return $
+    testGroup
+      "State Machine Tests"
+      [ qsmTests
+      ]

--- a/morpho-checkpoint-node/tests/test.hs
+++ b/morpho-checkpoint-node/tests/test.hs
@@ -3,6 +3,7 @@ import Test.Morpho.Crypto.ECDSASignature
 import Test.Morpho.Golden
 import Test.Morpho.Ledger.State
 import Test.Morpho.QSM
+import Test.Morpho.MantisIntegration
 import Test.Morpho.Serialisation
 import Test.Tasty
 import Prelude
@@ -21,5 +22,6 @@ tests = do
         utilsTests,
         serialiseTests,
         goldenTests,
-        qsmTests
+        qsmTests,
+        mantisIntegrationTests
       ]

--- a/morpho-checkpoint-node/tests/test.hs
+++ b/morpho-checkpoint-node/tests/test.hs
@@ -2,8 +2,6 @@ import Test.Morpho.Common.Utils
 import Test.Morpho.Crypto.ECDSASignature
 import Test.Morpho.Golden
 import Test.Morpho.Ledger.State
-import Test.Morpho.QSM
-import Test.Morpho.MantisIntegration
 import Test.Morpho.Serialisation
 import Test.Tasty
 import Prelude
@@ -21,7 +19,5 @@ tests = do
         ecdsaTests,
         utilsTests,
         serialiseTests,
-        goldenTests,
-        qsmTests,
-        mantisIntegrationTests
+        goldenTests
       ]

--- a/release.nix
+++ b/release.nix
@@ -8,14 +8,31 @@ let
   default = (import src { inherit src; });
   pkgs = default.pkgs;
 in {
-  checkpointing-node-exe = default.morpho-checkpoint-node.components.exes;
-  checkpointing-node-shell = default.shell;
-  checkpointing-node-run-tests = default.pkgs.stdenvNoCC.mkDerivation {
+  checkpoint-node-exe = default.morpho-checkpoint-node.components.exes;
+  checkpoint-node-shell = default.shell;
+  checkpoint-node-run-unit-tests = default.pkgs.stdenvNoCC.mkDerivation {
     inherit src;
     name = "checkpointing-node-run-tests";
     installPhase = ''
       cd morpho-checkpoint-node
       ${default.morpho-checkpoint-node.components.tests.test}/bin/test
+      touch $out'';
+  };
+  checkpoint-node-run-mantis-integration-tests = default.pkgs.stdenvNoCC.mkDerivation {
+    inherit src;
+    name = "checkpointing-node-mantis-integration-tests";
+    buildInputs = [ default.mantis ];
+    installPhase = ''
+      cd morpho-checkpoint-node
+      ${default.morpho-checkpoint-node.components.tests.mantis-integration-tests}/bin/mantis-integration-tests
+      touch $out'';
+  };
+  checkpoint-node-run-statemachine-tests = default.pkgs.stdenvNoCC.mkDerivation {
+    inherit src;
+    name = "checkpointing-node-statemachine-tests";
+    installPhase = ''
+      cd morpho-checkpoint-node
+      ${default.morpho-checkpoint-node.components.tests.state-machine-tests}/bin/state-machine-tests
       touch $out'';
   };
   check-code-formatting = pkgs.stdenvNoCC.mkDerivation {


### PR DESCRIPTION
See the individual commit messages for more context:

```
We add an integration test testing the signature format with the real
Mantis parser.

We inject the "signatureValidator" CLI tool coming from mantis through
Nix.

Note: these tests are pretty long to run (~2s/iteration). They also
require the user to have Mantis to their $PATH to correctly run. We
probably should extract them to their own cabal target.
```

```
We were unable to verify the signatures produced by Morpho on
Midnight. It turns out the secp256k1-haskell FFI binding it quite
loose type-wise and we swapped the r and s ECDSA parameters.
```

```
Some tests are pretty long to run, namely the state machine and mantis
integration ones. On top of that, the mantis integration tests are
expecting the user to have all the Mantis binaries in $PATH, which
might not necessarily be the case.

We extract these tests into 3 tests suites:

- test: the "standard" one. It's meant to be run frequently. The tests
  are pretty fast to complete and do not require anything wild in $PATH.
- state-machine-tests: the state machine tests do not require anything
  wild in $PATH either, however, they are pretty long to complete (~4min).
- mantis-integration-tests: these integration tests require Mantis to
  be in $PATH on top of being pretty long to run (~2min).

We create a realease.nix job for each of these tests to make them run
on hydra.
```