### PR TITLE
Measure the time it takes for a checkpoint to become stable

### DIFF
--- a/morpho-checkpoint-node/src/Morpho/Tracing/Metrics.hs
+++ b/morpho-checkpoint-node/src/Morpho/Tracing/Metrics.hs
@@ -1,19 +1,29 @@
 module Morpho.Tracing.Metrics
   ( MorphoMetrics (..),
     setupPrometheus,
+    UnstableBlockTimes,
+    newUnstableBlockTimes,
+    putUnstableTime,
+    getTimeToStable,
   )
 where
 
-import Cardano.Prelude
+import Cardano.Prelude hiding (atomically, STM)
+import Control.Monad.Class.MonadSTM.Strict
+import Data.Time
 import System.Metrics.Prometheus.Concurrent.RegistryT
 import System.Metrics.Prometheus.Metric.Gauge hiding (sample)
 import System.Metrics.Prometheus.Registry (RegistrySample)
+import Morpho.Ledger.PowTypes ( PowBlockNo(PowBlockNo) )
+import qualified Data.IntMap.Strict as IntMap
+import Data.IntMap.Strict (IntMap)
 
 data MorphoMetrics
   = MorphoMetrics
       { mLatestPowBlock :: Gauge,
         mMorphoStateUnstableCheckpoint :: Gauge,
         mMorphoStateStableCheckpoint :: Gauge,
+        mMorphoTimeToStable :: Gauge,
         mPushedCheckpoint :: Gauge,
         mNbVotesLastCheckpoint :: Gauge,
         mNbPeers :: Gauge
@@ -24,8 +34,38 @@ setupPrometheus = runRegistryT $ do
   currentPowNumber <- registerGauge "morpho_latest_pow_block_number" mempty
   mStableStateCheckpoint <- registerGauge "morpho_checkpoint_stable_state_pow_block_number" mempty
   mUnstableStateCheckpoint <- registerGauge "morpho_checkpoint_unstable_state_pow_block_number" mempty
+  mStableTime <- registerGauge "morpho_checkpoint_time_to_stable" mempty
   mpushedCheckpoint <- registerGauge "morpho_checkpoint_pushed_pow_block_number" mempty
   mNbVotes <- registerGauge "morpho_checkpoint_nb_votes_latest" mempty
   mnbp <- registerGauge "morpho_checkpoint_nb_peers" mempty
   rs <- sample
-  pure (MorphoMetrics currentPowNumber mUnstableStateCheckpoint mStableStateCheckpoint mpushedCheckpoint mNbVotes mnbp, rs)
+  pure (MorphoMetrics currentPowNumber mUnstableStateCheckpoint mStableStateCheckpoint mStableTime mpushedCheckpoint mNbVotes mnbp, rs)
+
+
+{-
+Utilities for measuring the time for an unstable checkpoint block to become stable
+We store an IntMap UTCTime to track the forge/receive times of unstable blocks,
+indexed by the block number on the POW chain. These timings are only correct under
+the assumption that block numbers are monotonically increasing and unique.
+-}
+
+type UnstableBlockTimes = StrictTVar IO (IntMap UTCTime)
+
+-- | Creates a new variable to store times of checkpoint blocks first appearing (still unstable)
+newUnstableBlockTimes :: STM IO UnstableBlockTimes
+newUnstableBlockTimes = newTVar IntMap.empty
+
+-- | Registers a checkpoint for a specific POW block to have appeared at a specific time
+-- Overrides any previous registered times for the same checkpoint
+putUnstableTime :: UnstableBlockTimes -> PowBlockNo -> UTCTime -> STM IO ()
+putUnstableTime times (PowBlockNo block) now = modifyTVar times (IntMap.insert block now)
+
+-- | Returns the time it took for a checkpoint with a specific POW block to become stable
+getTimeToStable :: UnstableBlockTimes -> PowBlockNo -> UTCTime -> STM IO (Maybe NominalDiffTime)
+getTimeToStable times (PowBlockNo block) now = do
+  -- Look up the block that just became stable, splitting the map at that point
+  -- Blocks before the now-stable block will also be stable, so we don't need to keep those timings around anymore
+  -- Blocks after the now-stable block are still unstable, so keep those timings around
+  (_, mUnstableTime, stillUnstableTs) <- IntMap.splitLookup block <$> readTVar times
+  writeTVar times stillUnstableTs
+  return $ (`diffUTCTime` now) <$> mUnstableTime


### PR DESCRIPTION
I paired with @NinjaTrappeur today, where we looked into timing the blocks, ending up with something like this: https://github.com/input-output-hk/ECIP-Checkpointing/commit/def2c8f41b87f8eef9e46f6ec1ff0f1e697844db

However that only measures times between new unstable checkpoints, which is not that useful for checking the expected time-to-stable time of them.

So in this PR I tried to implement a way to measure the time it takes for an unstable block to become stable.

I'm using an `intMap` for this, mapping from the `PowBlockNo` to the `UTCTime` representing the time at which the given block was forged/received. Once a block is stable, a lookup is performed to figure out how long it took, while also removing all now-stable blocks from the map.

This code relies on the potentially-wrong assumption that `PowBlockNo` is strictly monotonely increasing for new unstable checkpoints. This assumption makes the code much easier though, because otherwise we'd probably have to track block hashes and parents, etc. At least on Grafana I'm seeing that this assumption holds, so it's probably good enough.

I have absolutely not tested this code at all yet. I have yet to figure out how to do that.