### PR TITLE
metrics: add block number tracking

### DIFF
--- a/morpho-checkpoint-node/src/Morpho/Tracing/Metrics.hs
+++ b/morpho-checkpoint-node/src/Morpho/Tracing/Metrics.hs
@@ -1,3 +1,5 @@
+{-# LANGUAGE NamedFieldPuns #-}
+
 module Morpho.Tracing.Metrics
   ( MorphoMetrics (..),
     setupPrometheus,
@@ -18,6 +20,7 @@ data MorphoMetrics
         mMorphoStateUnstableCheckpoint :: Gauge,
         mMorphoStateStableCheckpoint :: Gauge,
         mMorphoBlockTime :: Gauge,
+        mMorphoBlockNumber :: Gauge,
         mPushedCheckpoint :: Gauge,
         mNbVotesLastCheckpoint :: Gauge,
         mNbPeers :: Gauge
@@ -25,15 +28,28 @@ data MorphoMetrics
 
 setupPrometheus :: IO (MorphoMetrics, IO RegistrySample)
 setupPrometheus = runRegistryT $ do
-  currentPowNumber <- registerGauge "morpho_latest_pow_block_number" mempty
-  mStableStateCheckpoint <- registerGauge "morpho_checkpoint_stable_state_pow_block_number" mempty
-  mUnstableStateCheckpoint <- registerGauge "morpho_checkpoint_unstable_state_pow_block_number" mempty
-  mpushedCheckpoint <- registerGauge "morpho_checkpoint_pushed_pow_block_number" mempty
-  mBlockTime <- registerGauge "morpho_block_time" mempty
-  mNbVotes <- registerGauge "morpho_checkpoint_nb_votes_latest" mempty
-  mnbp <- registerGauge "morpho_checkpoint_nb_peers" mempty
+  mLatestPowBlock <- registerGauge "morpho_latest_pow_block_number" mempty
+  mMorphoStateStableCheckpoint <- registerGauge "morpho_checkpoint_stable_state_pow_block_number" mempty
+  mMorphoStateUnstableCheckpoint <- registerGauge "morpho_checkpoint_unstable_state_pow_block_number" mempty
+  mPushedCheckpoint <- registerGauge "morpho_checkpoint_pushed_pow_block_number" mempty
+  mMorphoBlockTime <- registerGauge "morpho_block_time" mempty
+  mMorphoBlockNumber <- registerGauge "morpho_block_number" mempty
+  mNbVotesLastCheckpoint <- registerGauge "morpho_checkpoint_nb_votes_latest" mempty
+  mNbPeers <- registerGauge "morpho_checkpoint_nb_peers" mempty
   rs <- sample
-  pure (MorphoMetrics currentPowNumber mUnstableStateCheckpoint mStableStateCheckpoint mBlockTime mpushedCheckpoint mNbVotes mnbp, rs)
+  pure
+    ( MorphoMetrics
+        { mLatestPowBlock,
+          mMorphoStateUnstableCheckpoint,
+          mMorphoStateStableCheckpoint,
+          mMorphoBlockTime,
+          mMorphoBlockNumber,
+          mPushedCheckpoint,
+          mNbVotesLastCheckpoint,
+          mNbPeers
+        },
+      rs
+    )
 
 setTimeDiff :: StrictTVar IO (Maybe UTCTime) -> Gauge -> IO ()
 setTimeDiff lastBlockTsVar gauge = do


### PR DESCRIPTION
Tracking the nodes block number can be pretty useful to quickly detect
a fork. A forked node won't be able to generate more than 1 block for
each leadership round. Meaning, it'll end up with a different block
number from the rest of the connected nodes.