### PR TITLE
[ETCM-553] SRV topology support

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -221,71 +221,71 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: bd871878957113d50181d1c304ec16f34f7effbc
-  --sha256: 02wb63hp8pvkakwi4bvcy2c01gh9civbf3n9isgrbf52xyiwyz9j
+  tag: ed48cb22027f66f8f7437e24667085605f26052b
+  --sha256: 01qar94v8gc16padyz0psrj7is8y7q0631rvw2anmj9qviiwnw15
   subdir: ouroboros-network
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: bd871878957113d50181d1c304ec16f34f7effbc
-  --sha256: 02wb63hp8pvkakwi4bvcy2c01gh9civbf3n9isgrbf52xyiwyz9j
+  tag: ed48cb22027f66f8f7437e24667085605f26052b
+  --sha256: 01qar94v8gc16padyz0psrj7is8y7q0631rvw2anmj9qviiwnw15
   subdir: io-sim
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: bd871878957113d50181d1c304ec16f34f7effbc
-  --sha256: 02wb63hp8pvkakwi4bvcy2c01gh9civbf3n9isgrbf52xyiwyz9j
+  tag: ed48cb22027f66f8f7437e24667085605f26052b
+  --sha256: 01qar94v8gc16padyz0psrj7is8y7q0631rvw2anmj9qviiwnw15
   subdir: ouroboros-consensus
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: bd871878957113d50181d1c304ec16f34f7effbc
-  --sha256: 02wb63hp8pvkakwi4bvcy2c01gh9civbf3n9isgrbf52xyiwyz9j
+  tag: ed48cb22027f66f8f7437e24667085605f26052b
+  --sha256: 01qar94v8gc16padyz0psrj7is8y7q0631rvw2anmj9qviiwnw15
   subdir: typed-protocols
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: bd871878957113d50181d1c304ec16f34f7effbc
-  --sha256: 02wb63hp8pvkakwi4bvcy2c01gh9civbf3n9isgrbf52xyiwyz9j
+  tag: ed48cb22027f66f8f7437e24667085605f26052b
+  --sha256: 01qar94v8gc16padyz0psrj7is8y7q0631rvw2anmj9qviiwnw15
   subdir: typed-protocols-examples
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: bd871878957113d50181d1c304ec16f34f7effbc
-  --sha256: 02wb63hp8pvkakwi4bvcy2c01gh9civbf3n9isgrbf52xyiwyz9j
+  tag: ed48cb22027f66f8f7437e24667085605f26052b
+  --sha256: 01qar94v8gc16padyz0psrj7is8y7q0631rvw2anmj9qviiwnw15
   subdir: ouroboros-network-framework
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: bd871878957113d50181d1c304ec16f34f7effbc
-  --sha256: 02wb63hp8pvkakwi4bvcy2c01gh9civbf3n9isgrbf52xyiwyz9j
+  tag: ed48cb22027f66f8f7437e24667085605f26052b
+  --sha256: 01qar94v8gc16padyz0psrj7is8y7q0631rvw2anmj9qviiwnw15
   subdir: ouroboros-consensus/ouroboros-consensus-test-infra
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: bd871878957113d50181d1c304ec16f34f7effbc
-  --sha256: 02wb63hp8pvkakwi4bvcy2c01gh9civbf3n9isgrbf52xyiwyz9j
+  tag: ed48cb22027f66f8f7437e24667085605f26052b
+  --sha256: 01qar94v8gc16padyz0psrj7is8y7q0631rvw2anmj9qviiwnw15
   subdir: network-mux
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: bd871878957113d50181d1c304ec16f34f7effbc
-  --sha256: 02wb63hp8pvkakwi4bvcy2c01gh9civbf3n9isgrbf52xyiwyz9j
+  tag: ed48cb22027f66f8f7437e24667085605f26052b
+  --sha256: 01qar94v8gc16padyz0psrj7is8y7q0631rvw2anmj9qviiwnw15
   subdir: io-sim-classes
 
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: bd871878957113d50181d1c304ec16f34f7effbc
-  --sha256: 02wb63hp8pvkakwi4bvcy2c01gh9civbf3n9isgrbf52xyiwyz9j
+  tag: ed48cb22027f66f8f7437e24667085605f26052b
+  --sha256: 01qar94v8gc16padyz0psrj7is8y7q0631rvw2anmj9qviiwnw15
   subdir: Win32-network
 
 source-repository-package

--- a/configuration/ec2-test-topology.json
+++ b/configuration/ec2-test-topology.json
@@ -1,10 +1,5 @@
 [
   {
-    "nodeAddress": {
-      "addr": "18.130.216.242",
-      "port": 3000,
-      "valency": 1
-    },
     "nodeId": 0,
     "producers": [
       {
@@ -55,11 +50,6 @@
     ]
   },
   {
-    "nodeAddress": {
-      "addr": "3.10.235.25",
-      "port": 3000,
-      "valency": 1
-    },
     "nodeId": 1,
     "producers": [
       {
@@ -110,11 +100,6 @@
     ]
   },
   {
-    "nodeAddress": {
-      "addr": "35.176.19.127",
-      "port": 3000,
-      "valency": 1
-    },
     "nodeId": 2,
     "producers": [
       {
@@ -165,11 +150,6 @@
     ]
   },
   {
-    "nodeAddress": {
-      "addr": "18.130.88.117",
-      "port": 3000,
-      "valency": 1
-    },
     "nodeId": 3,
     "producers": [
       {
@@ -220,11 +200,6 @@
     ]
   },
   {
-    "nodeAddress": {
-      "addr": "18.130.123.202",
-      "port": 3000,
-      "valency": 1
-    },
     "nodeId": 4,
     "producers": [
       {
@@ -275,11 +250,6 @@
     ]
   },
   {
-    "nodeAddress": {
-      "addr": "3.10.212.254",
-      "port": 3000,
-      "valency": 1
-    },
     "nodeId": 5,
     "producers": [
       {
@@ -330,11 +300,6 @@
     ]
   },
   {
-    "nodeAddress": {
-      "addr": "3.9.139.127",
-      "port": 3000,
-      "valency": 1
-    },
     "nodeId": 6,
     "producers": [
       {
@@ -385,11 +350,6 @@
     ]
   },
   {
-    "nodeAddress": {
-      "addr": "18.130.123.51",
-      "port": 3000,
-      "valency": 1
-    },
     "nodeId": 7,
     "producers": [
       {
@@ -440,11 +400,6 @@
     ]
   },
   {
-    "nodeAddress": {
-      "addr": "35.178.210.135",
-      "port": 3000,
-      "valency": 1
-    },
     "nodeId": 8,
     "producers": [
       {
@@ -495,11 +450,6 @@
     ]
   },
   {
-    "nodeAddress": {
-      "addr": "3.8.2.92",
-      "port": 3000,
-      "valency": 1
-    },
     "nodeId": 9,
     "producers": [
       {

--- a/configuration/morpho-topology.json
+++ b/configuration/morpho-topology.json
@@ -1,10 +1,5 @@
 [
   {
-    "nodeAddress": {
-      "addr": "127.0.0.1",
-      "port": 3000,
-      "valency": 1
-    },
     "nodeId": 0,
     "producers": [
       {

--- a/morpho-checkpoint-node/src/Morpho/Config/Topology.hs
+++ b/morpho-checkpoint-node/src/Morpho/Config/Topology.hs
@@ -64,7 +64,6 @@ instance FromJSON NodeAddress where
 data NodeSetup
   = NodeSetup
       { nodeId :: !Word64,
-        nodeAddress :: !NodeAddress,
         producers :: ![RemoteAddress]
       }
   deriving (Show, Eq)

--- a/morpho-checkpoint-node/src/Morpho/Tracing/TracingOrphanInstances.hs
+++ b/morpho-checkpoint-node/src/Morpho/Tracing/TracingOrphanInstances.hs
@@ -1330,10 +1330,12 @@ instance HasSeverityAnnotation (WithDomainName DnsTrace) where
     DnsTraceLookupException {} -> Error
     DnsTraceLookupAError {} -> Error
     DnsTraceLookupAAAAError {} -> Error
+    DnsTraceLookupSRVError {} -> Error
     DnsTraceLookupIPv6First -> Debug
     DnsTraceLookupIPv4First -> Debug
     DnsTraceLookupAResult {} -> Debug
     DnsTraceLookupAAAAResult {} -> Debug
+    DnsTraceLookupSRVResult {} -> Debug
 
 instance HasPrivacyAnnotation (WithDomainName (SubscriptionTrace Socket.SockAddr))
 

--- a/morpho-checkpoint-node/tests/Test/Morpho/Examples.hs
+++ b/morpho-checkpoint-node/tests/Test/Morpho/Examples.hs
@@ -242,6 +242,5 @@ exampleTopology = NetworkTopology [t1]
     t1 =
       NodeSetup
         { nodeId = 0,
-          nodeAddress = (NodeAddress (NodeHostAddress (Just "18.130.216.242")) 3000),
-          producers = [RemoteAddress "3.10.235.25" 3000 1]
+          producers = [RemoteAddress "3.10.235.25" (Just 3000) 1]
         }

--- a/morpho-checkpoint-node/tests/configuration/Golden/Topology.json
+++ b/morpho-checkpoint-node/tests/configuration/Golden/Topology.json
@@ -1,10 +1,5 @@
 [
   {
-    "nodeAddress": {
-      "addr": "18.130.216.242",
-      "port": 3000,
-      "valency": 1
-    },
     "nodeId": 0,
     "producers": [
       {

--- a/morpho-checkpoint-node/tests/configuration/QSM/prop_1/topology.json
+++ b/morpho-checkpoint-node/tests/configuration/QSM/prop_1/topology.json
@@ -1,10 +1,5 @@
 [
   {
-    "nodeAddress": {
-      "addr": "127.0.0.1",
-      "port": 3000,
-      "valency": 1
-    },
     "nodeId": 0,
     "producers": [
       {
@@ -25,11 +20,6 @@
     ]
   },
   {
-    "nodeAddress": {
-        "addr": "127.0.0.1",
-        "port": 3002,
-        "valency": 1
-      },
     "nodeId": 1,
     "producers": [
       {
@@ -50,11 +40,6 @@
     ]
   },
   {
-    "nodeAddress": {
-        "addr": "127.0.0.1",
-        "port": 3004,
-        "valency": 1
-      },
     "nodeId": 2,
     "producers": [
       {

--- a/morpho-checkpoint-node/tests/configuration/QSM/prop_2/topology.json
+++ b/morpho-checkpoint-node/tests/configuration/QSM/prop_2/topology.json
@@ -1,10 +1,5 @@
 [
   {
-    "nodeAddress": {
-      "addr": "127.0.0.1",
-      "port": 3000,
-      "valency": 1
-    },
     "nodeId": 0,
     "producers": [
       {
@@ -20,11 +15,6 @@
     ]
   },
   {
-    "nodeAddress": {
-        "addr": "127.0.0.1",
-        "port": 3002,
-        "valency": 1
-      },
     "nodeId": 1,
     "producers": [
       {

--- a/morpho-checkpoint-node/tests/configuration/QSM/prop_3/topology.json
+++ b/morpho-checkpoint-node/tests/configuration/QSM/prop_3/topology.json
@@ -1,10 +1,5 @@
 [
   {
-    "nodeAddress": {
-      "addr": "127.0.0.1",
-      "port": 3000,
-      "valency": 1
-    },
     "nodeId": 0,
     "producers": [
       {
@@ -20,11 +15,6 @@
     ]
   },
   {
-    "nodeAddress": {
-        "addr": "127.0.0.1",
-        "port": 3002,
-        "valency": 1
-      },
     "nodeId": 1,
     "producers": [
       {

--- a/morpho-checkpoint-node/tests/configuration/QSM/prop_4/topology.json
+++ b/morpho-checkpoint-node/tests/configuration/QSM/prop_4/topology.json
@@ -1,10 +1,5 @@
 [
   {
-    "nodeAddress": {
-      "addr": "127.0.0.1",
-      "port": 3000,
-      "valency": 1
-    },
     "nodeId": 0,
     "producers": [
       {
@@ -20,11 +15,6 @@
     ]
   },
   {
-    "nodeAddress": {
-        "addr": "127.0.0.1",
-        "port": 3002,
-        "valency": 1
-      },
     "nodeId": 1,
     "producers": [
       {

--- a/scripts/generateTopology.py
+++ b/scripts/generateTopology.py
@@ -22,11 +22,6 @@ Usage example:
 # cat topology.json
 [
   {
-    "nodeAddress": {
-      "addr": "127.0.0.1",
-      "port": 3001,
-      "valency": 1
-    },
     "nodeId": 0,
     "producers": [
       {
@@ -49,14 +44,9 @@ Usage example:
 
 defaultPort = 3000
 
-def genPeer(nodeId, nodeAddr):
+def genPeer(nodeId):
     return {
         'nodeId' : int(nodeId),
-        'nodeAddress' : {
-            'addr': nodeAddr,
-            'port': defaultPort,
-            'valency': 1
-        },
         'producers': [
             {
                 'addr':peer[1],
@@ -68,6 +58,6 @@ def genPeer(nodeId, nodeAddr):
 
 if __name__ == '__main__':
     addresses = json.loads(''.join(sys.stdin.readlines()))
-    t = [ genPeer(node[0], node[1]) for node in addresses.items() ]
+    t = [ genPeer(node[0]) for node in addresses.items() ]
     print(json.dumps(t, sort_keys=True, indent=2))
     exit(0)


### PR DESCRIPTION
- Removes the `nodeAddress` field in the topology files, it was unused and would make the next commit harder
- Updates to ouroboros-network supporting SRV records, as implemented in https://github.com/input-output-hk/ouroboros-network/commit/ed48cb22027f66f8f7437e24667085605f26052b. This is only a very basic implementation and shouldn't be relied upon. I'm only implementing this so we can use this feature for the Nomad/Consul deployment, as it allows using https://www.consul.io/docs/discovery/dns

A topology producer element can now have the form
```json
{
  "addr": "_morpho._tcp.example.com.",
  "valency": 1
}
```

Notably without a `"port"`. This looks up the SRV record at the given domain, whose first result (independent of priority and weight) is connected to.

Important: Note the `.` at the end of the domain, which is necessary at the moment.