### PR TITLE
[ETCM-656] Extend getLatestBlock RPC call with parent checkpoint arg

### DIFF
--- a/morpho-checkpoint-node/src/Morpho/Ledger/PowTypes.hs
+++ b/morpho-checkpoint-node/src/Morpho/Ledger/PowTypes.hs
@@ -8,6 +8,7 @@ module Morpho.Ledger.PowTypes
   ( PowBlockNo (..),
     PowBlockHash (..),
     PowBlockRef (..),
+    LatestBlockResponse (..),
     Vote (..),
     Checkpoint (..),
     genesisCheckpoint,
@@ -55,6 +56,12 @@ data PowBlockRef = PowBlockRef
   deriving stock (Show, Eq, Ord, Generic)
   deriving anyclass (Serialise)
   deriving anyclass (NoThunks)
+
+newtype LatestBlockResponse = LatestBlockResponse
+  { block :: Maybe PowBlockRef
+  }
+  deriving stock (Show, Eq, Generic)
+  deriving anyclass (ToJSON, FromJSON)
 
 instance ToJSON PowBlockRef where
   toJSON PowBlockRef {..} =

--- a/morpho-checkpoint-node/src/Morpho/RPC/Request.hs
+++ b/morpho-checkpoint-node/src/Morpho/RPC/Request.hs
@@ -8,11 +8,12 @@ import Cardano.Prelude
 import Data.Aeson
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.Text as T
+import Morpho.Ledger.PowTypes
 import Morpho.RPC.Types
 import Network.HTTP.Client
 
-getLatestPoWBlock :: Text -> Int -> IO (Either Text LatestPoWBlockResponse)
-getLatestPoWBlock rpcUrl k = do
+getLatestPoWBlock :: Text -> Int -> PowBlockRef -> IO (Either Text LatestPoWBlockResponse)
+getLatestPoWBlock rpcUrl k lastCheckpointedBlock = do
   r <- request
   m <- morphoManager
   parseResponse . responseBody <$> httpLbs r m
@@ -28,7 +29,7 @@ getLatestPoWBlock rpcUrl k = do
         initReq
           { method = "POST",
             requestHeaders = [("content-type", "application/json")],
-            requestBody = RequestBodyLBS $ encode $ mkLatestBlockRequest k
+            requestBody = RequestBodyLBS $ encode $ mkLatestBlockRequest k (powBlockHash lastCheckpointedBlock)
           }
 
 pushPoWNodeCheckpoint :: Text -> PoWBlockchainCheckpoint -> IO (Either Text PoWNodeCheckpointResponse)

--- a/morpho-checkpoint-node/src/Morpho/RPC/Request.hs
+++ b/morpho-checkpoint-node/src/Morpho/RPC/Request.hs
@@ -15,10 +15,12 @@ getLatestPoWBlock :: Text -> Int -> IO (Either Text LatestPoWBlockResponse)
 getLatestPoWBlock rpcUrl k = do
   r <- request
   m <- morphoManager
-  parseResponse . BL.toStrict . responseBody <$> httpLbs r m
+  parseResponse . responseBody <$> httpLbs r m
   where
-    parseResponse :: ByteString -> Either Text LatestPoWBlockResponse
-    parseResponse = first T.pack . eitherDecode' . BL.fromStrict
+    parseResponse :: BL.ByteString -> Either Text LatestPoWBlockResponse
+    parseResponse bytes = case eitherDecode' bytes of
+      Left err -> Left $ "Error trying to decode rpc response " <> decodeUtf8 (BL.toStrict bytes) <> ": " <> T.pack err
+      Right result -> Right result
     request :: IO Request
     request = do
       initReq <- parseRequest $ T.unpack rpcUrl -- "http://127.0.0.1:8546"
@@ -33,10 +35,12 @@ pushPoWNodeCheckpoint :: Text -> PoWBlockchainCheckpoint -> IO (Either Text PoWN
 pushPoWNodeCheckpoint rpcUrl mc = do
   r <- request
   m <- morphoManager
-  parseResponse . BL.toStrict . responseBody <$> httpLbs r m
+  parseResponse . responseBody <$> httpLbs r m
   where
-    parseResponse :: ByteString -> Either Text PoWNodeCheckpointResponse
-    parseResponse = first T.pack . eitherDecode' . BL.fromStrict
+    parseResponse :: BL.ByteString -> Either Text PoWNodeCheckpointResponse
+    parseResponse bytes = case eitherDecode' bytes of
+      Left err -> Left $ "Error trying to decode rpc response " <> decodeUtf8 (BL.toStrict bytes) <> ": " <> T.pack err
+      Right result -> Right result
     request :: IO Request
     request = do
       initReq <- parseRequest $ T.unpack rpcUrl

--- a/morpho-checkpoint-node/src/Morpho/Tracing/TracingOrphanInstances.hs
+++ b/morpho-checkpoint-node/src/Morpho/Tracing/TracingOrphanInstances.hs
@@ -197,6 +197,10 @@ instance ToObject PoWNodeRpcTrace where
       [ "kind" .= String "RpcLatestPoWBlock",
         "block" .= show blk
       ]
+  toObject _verb RpcNoLatestPoWBlock =
+    mkObject
+      [ "kind" .= String "RpcNoLatestPoWBlock"
+      ]
   toObject _verb (RpcNetworkError op err) =
     mkObject
       [ "kind" .= String "RpcNetworkError",
@@ -215,6 +219,7 @@ instance HasPrivacyAnnotation PoWNodeRpcTrace
 instance HasSeverityAnnotation PoWNodeRpcTrace where
   getSeverityAnnotation RpcPushedCheckpoint {} = Notice
   getSeverityAnnotation RpcLatestPoWBlock {} = Notice
+  getSeverityAnnotation RpcNoLatestPoWBlock {} = Notice
   getSeverityAnnotation RpcNetworkError {} = Error
   getSeverityAnnotation RpcResponseParseError {} = Error
 

--- a/morpho-checkpoint-node/src/Morpho/Tracing/Types.hs
+++ b/morpho-checkpoint-node/src/Morpho/Tracing/Types.hs
@@ -19,6 +19,7 @@ data PoWNodeRpcOperation = FetchLatestPoWBlock | PushCheckpoint
 data PoWNodeRpcTrace
   = RpcPushedCheckpoint PoWNodeCheckpointResponse
   | RpcLatestPoWBlock LatestPoWBlockResponse
+  | RpcNoLatestPoWBlock
   | RpcNetworkError PoWNodeRpcOperation String
   | RpcResponseParseError PoWNodeRpcOperation Text
   deriving (Eq, Show)

--- a/morpho-checkpoint-node/tests/Test/Morpho/Examples.hs
+++ b/morpho-checkpoint-node/tests/Test/Morpho/Examples.hs
@@ -25,7 +25,7 @@ import Morpho.Config.Topology
 import Morpho.Config.Types
 import Morpho.Crypto.ECDSASignature
 import Morpho.Ledger.Block
-import Morpho.Ledger.PowTypes
+import Morpho.Ledger.PowTypes hiding (block)
 import Morpho.Ledger.Serialise ()
 import Morpho.Ledger.State
 import Morpho.Ledger.Tx

--- a/morpho-checkpoint-node/tests/Test/Morpho/Ledger/State.hs
+++ b/morpho-checkpoint-node/tests/Test/Morpho/Ledger/State.hs
@@ -21,7 +21,7 @@ import Morpho.Common.Conversions
 import Morpho.Crypto.ECDSASignature
 import Morpho.Ledger.Block
 import Morpho.Ledger.Forge
-import Morpho.Ledger.PowTypes
+import Morpho.Ledger.PowTypes hiding (block)
 import Morpho.Ledger.State
 import Morpho.Ledger.Tx
 import Morpho.Ledger.Update


### PR DESCRIPTION
This should ensure that we can't issue checkpoints for multiple forks of a POW chain. This relies on the equivalent changes in mantis with [ETCM-655]