### PR TITLE
Normalize domain names in topology

### DIFF
--- a/morpho-checkpoint-node/morpho-checkpoint-node.cabal
+++ b/morpho-checkpoint-node/morpho-checkpoint-node.cabal
@@ -63,6 +63,7 @@ library
         containers,
         contra-tracer,
         directory,
+        dns,
         filepath,
         hashable,
         hostname,

--- a/morpho-checkpoint-node/src/Morpho/Node/Run.hs
+++ b/morpho-checkpoint-node/src/Morpho/Node/Run.hs
@@ -42,6 +42,7 @@ import Morpho.Tracing.Metrics
 import Morpho.Tracing.Tracers
 import Morpho.Tracing.TracingOrphanInstances
 import Morpho.Tracing.Types
+import Network.DNS.Utils (normalize)
 import Network.HTTP.Client hiding (Proxy)
 import Network.Socket
 import Ouroboros.Consensus.Block.Abstract
@@ -120,7 +121,7 @@ handleSimpleNode pInfo nodeTracers env = do
       producerSubscription :: RemoteAddress -> DnsSubscriptionTarget
       producerSubscription ra =
         DnsSubscriptionTarget
-          { dstDomain = BSC.pack (raAddress ra),
+          { dstDomain = normalize (BSC.pack (raAddress ra)),
             dstPort = raPort ra,
             dstValency = raValency ra
           }


### PR DESCRIPTION
This ensures that domain names are normalized, meaning that a "." is added to the end if it's missing and more. Not doing that can cause IllegalDomain errors for non-normalized domain names.