### PR TITLE
Improved initialization tracing and initialize topology outside of main runner function

### DIFF
--- a/morpho-checkpoint-node/app/morpho-checkpoint-node.hs
+++ b/morpho-checkpoint-node/app/morpho-checkpoint-node.hs
@@ -1,5 +1,4 @@
 import Cardano.Prelude
-import Cardano.Shell.Lib
 import Morpho.Common.Parsers
 import Morpho.Common.TopHandler
 import Morpho.Config.Combined
@@ -10,6 +9,4 @@ main :: IO ()
 main = toplevelExceptionHandler $ do
   (file, cliConfig) <- runCLI
   nodeConfig <- getConfiguration cliConfig file
-  (env, features) <- configurationToEnv nodeConfig
-  runCardanoApplicationWithFeatures features $
-    CardanoApplication $ run env
+  withEnv nodeConfig run

--- a/morpho-checkpoint-node/morpho-checkpoint-node.cabal
+++ b/morpho-checkpoint-node/morpho-checkpoint-node.cabal
@@ -104,38 +104,15 @@ executable morpho-checkpoint-node
     main-is:            morpho-checkpoint-node.hs
     hs-source-dirs:     app
     default-language:   Haskell2010
-    default-extensions: NoImplicitPrelude OverloadedStrings
+    default-extensions: NoImplicitPrelude
     ghc-options:
         -threaded -Wall -O2 -with-rtsopts=-T
         -fno-warn-unticked-promoted-constructors
 
     build-depends:
         base >=4.12.0.0,
-        aeson,
-        bytestring,
         cardano-prelude,
-        cardano-shell,
-        cborg,
-        containers,
-        contra-tracer,
-        directory,
-        ekg-prometheus-adapter,
-        formatting,
-        io-sim-classes,
-        iohk-monitoring,
-        iproute,
-        lens,
-        mtl,
-        morpho-checkpoint-node,
-        network,
-        ouroboros-network,
-        ouroboros-consensus,
-        optparse-applicative,
-        safe-exceptions,
-        stm,
-        text,
-        time,
-        unix
+        morpho-checkpoint-node
 
 test-suite test
     type:               exitcode-stdio-1.0
@@ -218,7 +195,6 @@ test-suite state-machine-tests
         async,
         barbies,
         bytestring,
-        cardano-shell,
         cardano-crypto-class,
         cborg,
         containers,

--- a/morpho-checkpoint-node/src/Morpho/Tracing/Tracers.hs
+++ b/morpho-checkpoint-node/src/Morpho/Tracing/Tracers.hs
@@ -71,7 +71,7 @@ import Prelude (String, show)
 
 data Tracers peer localPeer h c = Tracers
   { -- | Used for top-level morpho traces during initialization
-    mainTracer :: Tracer IO String,
+    morphoInitTracer :: Tracer IO MorphoInitTrace,
     -- | Trace the ChainDB (flag '--trace-chain-db' will turn on textual output)
     chainDBTracer :: Tracer IO (ChainDB.TraceEvent (MorphoBlock h c)),
     -- | Consensus-specific tracers.
@@ -200,10 +200,10 @@ mkTracers traceOptions tracer = do
       <*> counting (liftCounting staticMetaCC name "forge-state-update-error" tracer)
   pure
     Tracers
-      { mainTracer =
+      { morphoInitTracer =
           annotateSeverity $
             toLogObject' tracingVerbosity $
-              appendName "Main" tracer,
+              appendName "MorphoInit" tracer,
         chainDBTracer =
           tracerOnOff (traceChainDB traceOptions) $
             annotateSeverity $

--- a/morpho-checkpoint-node/src/Morpho/Tracing/Types.hs
+++ b/morpho-checkpoint-node/src/Morpho/Tracing/Types.hs
@@ -1,20 +1,76 @@
+{-# LANGUAGE MultiParamTypeClasses #-}
+
 module Morpho.Tracing.Types
   ( PoWNodeRpcOperation (..),
     PoWNodeRpcTrace (..),
     ExtractStateTrace (..),
+    MorphoInitTrace (..),
   )
 where
 
+import Cardano.BM.Data.Severity
+import Cardano.BM.Data.Tracer
 import Cardano.Prelude
+import Data.Aeson hiding (Error)
+import Morpho.Config.Topology
 import Morpho.Ledger.Block
 import Morpho.Ledger.PowTypes
 import Morpho.Ledger.State
 import Morpho.Ledger.Update
 import Morpho.RPC.Types
+import Ouroboros.Consensus.NodeId
 import Prelude (String)
 
 data PoWNodeRpcOperation = FetchLatestPoWBlock | PushCheckpoint
   deriving (Eq, Show)
+
+data MorphoInitTrace
+  = NotFoundInTopology NodeAddress CoreNodeId
+  | ProducerList NodeAddress CoreNodeId [RemoteAddress]
+  | PerformingDBValidation
+  | PrometheusException IOException
+  deriving (Eq, Show)
+
+instance HasSeverityAnnotation MorphoInitTrace where
+  getSeverityAnnotation NotFoundInTopology {} = Error
+  getSeverityAnnotation ProducerList {} = Info
+  getSeverityAnnotation PerformingDBValidation {} = Info
+  getSeverityAnnotation PrometheusException {} = Error
+
+instance HasPrivacyAnnotation MorphoInitTrace
+
+instance Transformable Text IO MorphoInitTrace where
+  trTransformer = trStructuredText
+
+instance ToObject MorphoInitTrace where
+  toObject _ (NotFoundInTopology addr nid) =
+    mkObject
+      [ "kind" .= String "NotFoundInTopology",
+        "addr" .= String (show addr),
+        "nodeId" .= String (show nid)
+      ]
+  toObject _ (ProducerList addr nid prods) =
+    mkObject
+      [ "kind" .= String "ProducerList",
+        "addr" .= String (show addr),
+        "nodeId" .= String (show nid),
+        "producers" .= String (show prods)
+      ]
+  toObject _ PerformingDBValidation =
+    mkObject
+      [ "kind" .= String "PerformingDBValidation"
+      ]
+  toObject _ (PrometheusException err) =
+    mkObject
+      [ "kind" .= String "PrometheusException",
+        "error" .= String (show err)
+      ]
+
+instance HasTextFormatter MorphoInitTrace where
+  formatText (NotFoundInTopology addr nid) _ = "Own address " <> show addr <> " Node Id " <> show nid <> " not found in topology"
+  formatText (ProducerList addr nid prods) _ = "I am Node " <> show addr <> " Id: " <> show nid <> ". My producers are " <> show prods
+  formatText PerformingDBValidation _ = "Performing DB validation"
+  formatText (PrometheusException err) _ = "Prometheus exception: " <> show err
 
 data PoWNodeRpcTrace
   = RpcPushedCheckpoint PoWNodeCheckpointResponse

--- a/morpho-checkpoint-node/src/Morpho/Tracing/Types.hs
+++ b/morpho-checkpoint-node/src/Morpho/Tracing/Types.hs
@@ -25,8 +25,8 @@ data PoWNodeRpcOperation = FetchLatestPoWBlock | PushCheckpoint
   deriving (Eq, Show)
 
 data MorphoInitTrace
-  = NotFoundInTopology NodeAddress CoreNodeId
-  | ProducerList NodeAddress CoreNodeId [RemoteAddress]
+  = NotFoundInTopology CoreNodeId
+  | ProducerList CoreNodeId [RemoteAddress]
   | PerformingDBValidation
   | PrometheusException IOException
   deriving (Eq, Show)
@@ -43,16 +43,14 @@ instance Transformable Text IO MorphoInitTrace where
   trTransformer = trStructuredText
 
 instance ToObject MorphoInitTrace where
-  toObject _ (NotFoundInTopology addr nid) =
+  toObject _ (NotFoundInTopology nid) =
     mkObject
       [ "kind" .= String "NotFoundInTopology",
-        "addr" .= String (show addr),
         "nodeId" .= String (show nid)
       ]
-  toObject _ (ProducerList addr nid prods) =
+  toObject _ (ProducerList nid prods) =
     mkObject
       [ "kind" .= String "ProducerList",
-        "addr" .= String (show addr),
         "nodeId" .= String (show nid),
         "producers" .= String (show prods)
       ]
@@ -67,8 +65,8 @@ instance ToObject MorphoInitTrace where
       ]
 
 instance HasTextFormatter MorphoInitTrace where
-  formatText (NotFoundInTopology addr nid) _ = "Own address " <> show addr <> " Node Id " <> show nid <> " not found in topology"
-  formatText (ProducerList addr nid prods) _ = "I am Node " <> show addr <> " Id: " <> show nid <> ". My producers are " <> show prods
+  formatText (NotFoundInTopology nid) _ = "Own node id " <> show nid <> " not found in topology"
+  formatText (ProducerList nid prods) _ = "I am node id " <> show nid <> ". My producers are " <> show prods
   formatText PerformingDBValidation _ = "Performing DB validation"
   formatText (PrometheusException err) _ = "Prometheus exception: " <> show err
 

--- a/morpho-checkpoint-node/tests/Test/Morpho/QSM.hs
+++ b/morpho-checkpoint-node/tests/Test/Morpho/QSM.hs
@@ -17,7 +17,6 @@ module Test.Morpho.QSM
 where
 
 import Barbies
-import Cardano.Shell.Lib
 import Control.Concurrent.Async
 import Control.Monad (forM, forM_, when)
 import Control.Monad.IO.Class
@@ -368,11 +367,8 @@ runDualNode createDir testId nodeId = do
   mockNode <- runSimpleMock $ 8446 + 100 * testId + 2 * nodeId
 
   nodeConfig <- getConfiguration cliConfig configFile
-  (env, features) <- configurationToEnv nodeConfig
-  node <-
-    async $
-      runCardanoApplicationWithFeatures features $
-        CardanoApplication $ run env
+
+  node <- async $ withEnv nodeConfig run
 
   link node
   return $ NodeHandle nodeId mockNode node


### PR DESCRIPTION
Now properly shows severities of morpho initialization messages. The topology initialization is now done outside of the main `run` function.

This PR is based on #27 