### PR TITLE
Update ouroboros-network and don't require socket

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -154,8 +154,8 @@ source-repository-package
 source-repository-package
   type: git
   location: https://github.com/input-output-hk/ouroboros-network
-  tag: 73df20a62b723d800f381d0ff25d0b7dbf62c2bc
-  --sha256: 1r6a7gizzbhvxkjnlzkxach98h0hmjznr5bkn47xhfxyvb0sdk9g
+  tag: 410f06ebc6403a105524c3c7e4ff93048598055d
+  --sha256: 0ls7x3yz1krbwp66dnbjg597qw1gqwygjffyww3pd617rvywj2m9
   subdir:
     ouroboros-network
     io-sim

--- a/configuration/morpho-configuration.yaml
+++ b/configuration/morpho-configuration.yaml
@@ -24,7 +24,6 @@ FedPubKeys:
 NodePrivKeyFile: morpho-checkpoint-node/tests/configuration/Golden/secret-key-normal
 StableLedgerDepth: 6
 DatabaseDirectory: db
-SocketFile: socket
 NodePort: 1234
 
 TopologyFile: configuration/morpho-topology.json

--- a/morpho-checkpoint-node/src/Morpho/Common/Parsers.hs
+++ b/morpho-checkpoint-node/src/Morpho/Common/Parsers.hs
@@ -96,16 +96,6 @@ cliParsers =
                   <> metavar "FILEPATH"
                   <> help "Directory where the state is stored."
               ),
-      ncSocketFile =
-        parser $
-          SocketFile
-            <$> strOption
-              ( long "socket-dir"
-                  <> metavar "FILEPATH"
-                  <> help
-                    "Directory with local sockets:\
-                    \  ${dir}/node-{core,relay}-${node-id}.socket"
-              ),
       ncNodeHost =
         parser $
           option

--- a/morpho-checkpoint-node/src/Morpho/Common/Socket.hs
+++ b/morpho-checkpoint-node/src/Morpho/Common/Socket.hs
@@ -1,14 +1,11 @@
 module Morpho.Common.Socket
   ( nodeAddressInfo,
-    removeStaleLocalSocket,
   )
 where
 
 import Cardano.Prelude
 import Morpho.Config.Types
 import Network.Socket as Socket
-import System.Directory (removeFile)
-import System.IO.Error (isDoesNotExistError)
 import qualified Prelude
 
 nodeAddressInfo :: NodeAddress -> IO [AddrInfo]
@@ -24,12 +21,3 @@ nodeAddressInfo (NodeAddress hostAddr port) =
         { addrFlags = [AI_PASSIVE, AI_ADDRCONFIG],
           addrSocketType = Stream
         }
-
--- | Remove the socket file
-removeStaleLocalSocket :: FilePath -> IO ()
-removeStaleLocalSocket socketFp = do
-  removeFile socketFp
-    `catch` \e ->
-      if isDoesNotExistError e
-        then return ()
-        else throwIO e

--- a/morpho-checkpoint-node/src/Morpho/Config/Types.hs
+++ b/morpho-checkpoint-node/src/Morpho/Config/Types.hs
@@ -11,15 +11,10 @@
 module Morpho.Config.Types
   ( ConfigYamlFilePath (..),
     DbFile (..),
-    DelegationCertFile (..),
-    GenesisFile (..),
-    MiscellaneousFilepaths (..),
     NodeConfiguration_ (..),
     NodeConfiguration,
     NodeConfigurationFunctor,
     Protocol (..),
-    SigningKeyFile (..),
-    SocketFile (..),
     TopologyFile (..),
     TraceOptions_ (..),
     TraceOptions,
@@ -80,7 +75,6 @@ data NodeConfiguration_ w f = NodeConfiguration
     ncNodePrivKeyFile :: Wear w f FilePath,
     ncTopologyFile :: Wear w f TopologyFile,
     ncDatabaseDir :: Wear w f DbFile,
-    ncSocketFile :: Wear w f SocketFile,
     ncNodeHost :: Wear w f NodeHostAddress,
     ncNodePort :: Wear w f PortNumber,
     ncValidateDb :: Wear w f Bool,
@@ -174,7 +168,6 @@ configFieldName =
       ncNodePrivKeyFile = "NodePrivKeyFile",
       ncTopologyFile = "TopologyFile",
       ncDatabaseDir = "DatabaseDirectory",
-      ncSocketFile = "SocketFile",
       ncNodeHost = "NodeHost",
       ncNodePort = "NodePort",
       ncValidateDb = "ValidateDatabase",
@@ -243,8 +236,6 @@ configFieldParser =
       ncNodePrivKeyFile = Compose fromJSON,
       ncTopologyFile = TopologyFile <$> Compose fromJSON,
       ncDatabaseDir = DbFile <$> Compose fromJSON,
-      -- TODO: Remove
-      ncSocketFile = SocketFile <$> Compose fromJSON,
       ncNodeHost = NodeHostAddress . readMaybe . T.unpack <$> Compose fromJSON,
       ncNodePort = (fromIntegral :: Int -> PortNumber) <$> Compose fromJSON,
       ncValidateDb = Compose fromJSON,
@@ -338,13 +329,6 @@ instance FromJSON Protocol where
 data Protocol = MockedBFT
   deriving (Eq, Show)
 
-data MiscellaneousFilepaths = MiscellaneousFilepaths
-  { topFile :: !TopologyFile,
-    dBFile :: !DbFile,
-    socketFile :: !SocketFile
-  }
-  deriving (Show)
-
 newtype TopologyFile = TopologyFile
   {unTopology :: FilePath}
   deriving (Eq, Show)
@@ -352,22 +336,6 @@ newtype TopologyFile = TopologyFile
 newtype DbFile = DbFile
   {unDB :: FilePath}
   deriving (Eq, Show)
-
-newtype GenesisFile = GenesisFile
-  {unGenesisFile :: FilePath}
-  deriving (Eq, Ord, Show, IsString)
-
-newtype DelegationCertFile = DelegationCertFile
-  {unDelegationCert :: FilePath}
-  deriving (Show)
-
-newtype SocketFile = SocketFile
-  {unSocket :: FilePath}
-  deriving (Eq, Show)
-
-newtype SigningKeyFile = SigningKeyFile
-  {unSigningKey :: FilePath}
-  deriving (Eq, Ord, Show, IsString)
 
 nodeAddressToSockAddr :: NodeAddress -> SockAddr
 nodeAddressToSockAddr (NodeAddress addr port) =

--- a/morpho-checkpoint-node/src/Morpho/Ledger/Block.hs
+++ b/morpho-checkpoint-node/src/Morpho/Ledger/Block.hs
@@ -387,3 +387,4 @@ instance HasNetworkProtocolVersion (MorphoBlock h c) where
 instance SupportedNetworkProtocolVersion (MorphoBlock h c) where
   supportedNodeToNodeVersions _ = Map.singleton NodeToNodeV_6 MorphoNodeToNodeVersion1
   supportedNodeToClientVersions _ = Map.singleton NodeToClientV_8 MorphoNodeToClientVersion1
+  latestReleasedNodeVersion _ = (Just NodeToNodeV_6, Just NodeToClientV_8)

--- a/morpho-checkpoint-node/src/Morpho/Node/Env.hs
+++ b/morpho-checkpoint-node/src/Morpho/Node/Env.hs
@@ -68,7 +68,6 @@ configurationToEnv nc = do
           eStableLedgerDepth = ncStableLedgerDepth nc,
           eTopology = topology,
           eDatabaseDir = databaseDir,
-          eSocketFile = unSocket $ ncSocketFile nc,
           eNodeAddress = NodeAddress (ncNodeHost nc) (ncNodePort nc),
           eValidateDb = ncValidateDb nc
         },
@@ -133,7 +132,6 @@ data Env h c = Env
     eStableLedgerDepth :: Int,
     eTopology :: NetworkTopology,
     eDatabaseDir :: FilePath,
-    eSocketFile :: FilePath,
     eNodeAddress :: NodeAddress,
     eValidateDb :: Bool
   }

--- a/morpho-checkpoint-node/src/Morpho/Node/Run.hs
+++ b/morpho-checkpoint-node/src/Morpho/Node/Run.hs
@@ -100,8 +100,6 @@ handleSimpleNode pInfo nodeTracers env = do
   addresses <- nodeAddressInfo (eNodeAddress env)
   let ipv4Address = find ((== AF_INET) . addrFamily) addresses
       ipv6Address = find ((== AF_INET6) . addrFamily) addresses
-      localSocketPath = eSocketFile env
-  removeStaleLocalSocket localSocketPath
   let ipProducerAddrs :: [NodeAddress]
       dnsProducerAddrs :: [RemoteAddress]
       (ipProducerAddrs, dnsProducerAddrs) =
@@ -146,7 +144,7 @@ handleSimpleNode pInfo nodeTracers env = do
         DiffusionArguments
           { daIPv4Address = Right <$> ipv4Address,
             daIPv6Address = Right <$> ipv6Address,
-            daLocalAddress = Just $ Right localSocketPath,
+            daLocalAddress = Nothing,
             daIpProducers = ipProducers,
             daDnsProducers = dnsProducers,
             -- TODO probably we could use smaller values here.

--- a/morpho-checkpoint-node/src/Morpho/Node/Run.hs
+++ b/morpho-checkpoint-node/src/Morpho/Node/Run.hs
@@ -146,7 +146,7 @@ handleSimpleNode pInfo nodeTracers env = do
         DiffusionArguments
           { daIPv4Address = Right <$> ipv4Address,
             daIPv6Address = Right <$> ipv6Address,
-            daLocalAddress = Right localSocketPath,
+            daLocalAddress = Just $ Right localSocketPath,
             daIpProducers = ipProducers,
             daDnsProducers = dnsProducers,
             -- TODO probably we could use smaller values here.
@@ -240,11 +240,12 @@ handleSimpleNode pInfo nodeTracers env = do
         StdRunNodeArgs
           { srnBfcMaxConcurrencyBulkSync = Nothing,
             srnBfcMaxConcurrencyDeadline = Nothing,
-            srcChainDbValidateOverride = eValidateDb env,
+            srnChainDbValidateOverride = eValidateDb env,
             srnDatabasePath = eDatabaseDir env,
             srnDiffusionArguments = diffusionArguments,
             srnDiffusionTracers = diffusionTracers,
-            srnTraceChainDB = chainDBTracer nodeTracers
+            srnTraceChainDB = chainDBTracer nodeTracers,
+            srnEnableInDevelopmentVersions = False
           }
   lowLevelArgs <- stdLowLevelRunNodeArgsIO args stdRunNodeArgs
   let customizedLowLevelArgs =

--- a/morpho-checkpoint-node/src/Morpho/Node/RunNode.hs
+++ b/morpho-checkpoint-node/src/Morpho/Node/RunNode.hs
@@ -89,6 +89,9 @@ type instance CannotForge (MorphoBlock h c) = Void
 
 type instance ForgeStateUpdateError (MorphoBlock h c) = Void
 
+instance BlockSupportsMetrics (MorphoBlock h c) where
+  isSelfIssued = isSelfIssuedConstUnknown
+
 instance
   ( MorphoStateDefaultConstraints h c,
     HashAlgorithm h,

--- a/morpho-checkpoint-node/tests/Test/Morpho/Examples.hs
+++ b/morpho-checkpoint-node/tests/Test/Morpho/Examples.hs
@@ -202,7 +202,6 @@ exampleNodeConfig =
       ncNodePrivKeyFile = "/path/to/private/key",
       ncTopologyFile = TopologyFile "/path/to/topo.json",
       ncDatabaseDir = DbFile "/path/to/db",
-      ncSocketFile = SocketFile "/path/to/socket",
       ncNodeHost = NodeHostAddress (Just "127.0.0.1"),
       ncNodePort = 2345,
       ncValidateDb = True,

--- a/morpho-checkpoint-node/tests/Test/Morpho/QSM.hs
+++ b/morpho-checkpoint-node/tests/Test/Morpho/QSM.hs
@@ -360,7 +360,6 @@ runDualNode createDir testId nodeId = do
         (bpure (Left CliNoParser))
           { ncTopologyFile = Right $ TopologyFile $ configDir ++ "/topology.json",
             ncDatabaseDir = Right $ DbFile $ nodeDir ++ "/db",
-            ncSocketFile = Right $ SocketFile $ nodeDir ++ "/.socket",
             ncNodePort = Right $ fromIntegral $ 3000 + 2 * nodeId,
             ncValidateDb = Right True
           }

--- a/morpho-checkpoint-node/tests/configuration/Golden/Config.yaml
+++ b/morpho-checkpoint-node/tests/configuration/Golden/Config.yaml
@@ -27,7 +27,6 @@ NodePrivKeyFile: /path/to/private/key
 
 TopologyFile: "/path/to/topo.json"
 DatabaseDirectory: "/path/to/db"
-SocketFile: "/path/to/socket"
 NodeHost: "127.0.0.1"
 NodePort: 2345
 ValidateDatabase: True


### PR DESCRIPTION
Based on #27.

Updates ouroboros-network to master with decreased timeouts and SRV support (https://github.com/input-output-hk/ouroboros-network/commit/410f06ebc6403a105524c3c7e4ff93048598055d). Also includes a [recent PR](https://github.com/input-output-hk/ouroboros-network/pull/2958) that makes passing a socket optional. This is made use of in this PR to remove the need for a socket in morpho.

This PR is technically a breaking change, since the previously useless CLI option `--socket-dir` and config file field `SocketFile` are now an error if passed. The solution of course is to just remove these.