### PR TITLE
Derive ToJSON instances for trace types

### DIFF
--- a/morpho-checkpoint-node/morpho-checkpoint-node.cabal
+++ b/morpho-checkpoint-node/morpho-checkpoint-node.cabal
@@ -38,6 +38,7 @@ library
         Morpho.RPC.Abstract
         Morpho.RPC.JsonRpc
         Morpho.RPC.JsonRpcProtocol
+        Morpho.Tracing.OrphanToJSONInstances
         Morpho.Tracing.TracingOrphanInstances
         Morpho.Tracing.Types
         Morpho.Tracing.Tracers

--- a/morpho-checkpoint-node/morpho-checkpoint-node.cabal
+++ b/morpho-checkpoint-node/morpho-checkpoint-node.cabal
@@ -43,6 +43,7 @@ library
         Morpho.Tracing.Types
         Morpho.Tracing.Tracers
         Morpho.Tracing.Metrics
+        Morpho.Tracing.Verbosity
 
     hs-source-dirs:     src
     default-language:   Haskell2010
@@ -129,6 +130,7 @@ test-suite test
         Test.Morpho.Generators
         Test.Morpho.Golden
         Test.Morpho.Serialisation
+        Test.Morpho.Tracing
 
     default-language:   Haskell2010
     default-extensions: NoImplicitPrelude
@@ -159,7 +161,8 @@ test-suite test
         text,
         time,
         unordered-containers,
-        validation
+        validation,
+        vector
 
 test-suite mantis-integration-tests
     type:               exitcode-stdio-1.0
@@ -212,4 +215,6 @@ test-suite state-machine-tests
         stm,
         tasty,
         tasty-quickcheck,
-        text
+        text,
+        unordered-containers,
+        vector

--- a/morpho-checkpoint-node/src/Morpho/Config/Topology.hs
+++ b/morpho-checkpoint-node/src/Morpho/Config/Topology.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE BangPatterns #-}
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TemplateHaskell #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
@@ -39,7 +40,7 @@ data RemoteAddress = RemoteAddress
     -- a boolean value, @0@ means to ignore the address;
     raValency :: !Int
   }
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
 
 instance FromJSON NodeHostAddress where
   parseJSON (String ipStr) = case readMaybe $ T.unpack ipStr of

--- a/morpho-checkpoint-node/src/Morpho/Config/Types.hs
+++ b/morpho-checkpoint-node/src/Morpho/Config/Types.hs
@@ -74,6 +74,7 @@ data NodeConfiguration_ w f = NodeConfiguration
     ncNodeHost :: Wear w f NodeHostAddress,
     ncNodePort :: Wear w f PortNumber,
     ncValidateDb :: Wear w f Bool,
+    ncVerbosity :: Wear w f Int,
     ncLogging :: Wear w f Representation
   }
   deriving (Generic)
@@ -135,6 +136,7 @@ configFieldName =
       ncNodeHost = "NodeHost",
       ncNodePort = "NodePort",
       ncValidateDb = "ValidateDatabase",
+      ncVerbosity = "Verbosity",
       ncLogging = "Logging"
     }
 
@@ -171,6 +173,7 @@ configFieldParser =
       ncNodeHost = NodeHostAddress . readMaybe . T.unpack <$> Compose fromJSON,
       ncNodePort = (fromIntegral :: Int -> PortNumber) <$> Compose fromJSON,
       ncValidateDb = Compose fromJSON,
+      ncVerbosity = Compose fromJSON,
       ncLogging = Compose fromJSON
     }
 
@@ -184,7 +187,8 @@ configFieldDefault =
       ncSnapshotInterval = Just 60,
       ncPoWBlockFetchInterval = Just 1000000,
       ncNodeHost = Just (NodeHostAddress Nothing),
-      ncValidateDb = Just False
+      ncValidateDb = Just False,
+      ncVerbosity = Just 0
     }
 
 instance FromJSON SystemStart where

--- a/morpho-checkpoint-node/src/Morpho/Crypto/ECDSASignature.hs
+++ b/morpho-checkpoint-node/src/Morpho/Crypto/ECDSASignature.hs
@@ -88,7 +88,8 @@ data Signature = Signature
   deriving anyclass (Serialise)
   deriving (NoThunks)
 
-instance ToJSON Signature
+instance ToJSON Signature where
+  toJSON = String . sigToHex
 
 data KeyPair = KeyPair
   { pKey :: PublicKey,

--- a/morpho-checkpoint-node/src/Morpho/Ledger/PowTypes.hs
+++ b/morpho-checkpoint-node/src/Morpho/Ledger/PowTypes.hs
@@ -24,43 +24,33 @@ import NoThunks.Class
 newtype PowBlockNo = PowBlockNo {unPowBlockNo :: Int}
   deriving stock (Eq, Show, Generic)
   deriving newtype (Num, Ord, Real, Enum, Integral, ToJSON)
-  deriving anyclass (Serialise)
-  deriving anyclass (NoThunks)
+  deriving anyclass (NoThunks, Serialise)
 
 newtype PowBlockHash = PowBlockHash {unPowBlockHash :: Bytes}
   deriving stock (Eq, Show, Ord, Generic)
-  deriving anyclass (Serialise)
-  deriving anyclass (NoThunks)
-
-instance ToJSON PowBlockHash
+  deriving newtype (ToJSON)
+  deriving anyclass (NoThunks, Serialise)
 
 data PowBlockRef = PowBlockRef
   { powBlockNo :: PowBlockNo,
     powBlockHash :: PowBlockHash
   }
   deriving stock (Show, Eq, Ord, Generic)
-  deriving anyclass (Serialise)
-  deriving anyclass (NoThunks)
-
-instance ToJSON PowBlockRef
+  deriving anyclass (ToJSON, NoThunks, Serialise)
 
 data Vote = Vote
   { votedPowBlock :: PowBlockRef,
     voteSignature :: Signature
   }
   deriving stock (Show, Eq, Generic)
-  deriving anyclass (Serialise)
-  deriving (NoThunks)
-
-instance ToJSON Vote
+  deriving anyclass (ToJSON, NoThunks, Serialise)
 
 data Checkpoint = Checkpoint
   { checkpointedBlock :: PowBlockRef,
     chkpSignatures :: [Signature]
   }
   deriving stock (Eq, Show, Generic)
-  deriving anyclass (Serialise, ToJSON)
-  deriving (NoThunks)
+  deriving anyclass (ToJSON, NoThunks, Serialise)
 
 genesisCheckpoint :: Checkpoint
 genesisCheckpoint = Checkpoint (PowBlockRef (PowBlockNo 0) (PowBlockHash empty)) []

--- a/morpho-checkpoint-node/src/Morpho/Ledger/SnapshotTimeTravel.hs
+++ b/morpho-checkpoint-node/src/Morpho/Ledger/SnapshotTimeTravel.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
 {-# LANGUAGE RankNTypes #-}
@@ -21,7 +22,7 @@ import Ouroboros.Network.Block hiding (Tip)
 data TimeTravelError blk
   = LedgerStateNotFoundAt (Point blk)
   | ChainNotLongEnough Int Int
-  deriving (Show)
+  deriving (Show, Generic)
 
 getLatestStableLedgerState ::
   forall m blk.

--- a/morpho-checkpoint-node/src/Morpho/Ledger/State.hs
+++ b/morpho-checkpoint-node/src/Morpho/Ledger/State.hs
@@ -21,6 +21,7 @@ where
 
 import Cardano.Prelude
 import Codec.Serialise (Serialise)
+import Data.Aeson
 import qualified Data.Map as M
 import Morpho.Crypto.ECDSASignature
 import Morpho.Ledger.PowTypes
@@ -53,7 +54,7 @@ data MorphoTransactionError
   | MorphoInvalidSignature
   | MorphoDuplicateVote
   | MorphoUnknownPublicKey
-  deriving (Show, Eq, Generic, NoThunks, Serialise)
+  deriving (Show, Eq, Generic, NoThunks, ToJSON, Serialise)
 
 data MorphoError blk
   = MorphoTransactionError Vote MorphoTransactionError

--- a/morpho-checkpoint-node/src/Morpho/Ledger/Update.hs
+++ b/morpho-checkpoint-node/src/Morpho/Ledger/Update.hs
@@ -325,7 +325,8 @@ voteBlockRef cfg ref = case sign sk bytes of
     bytes = powBlockRefToBytes ref
 
 newtype VoteError = FailedToSignBlockRef PowBlockRef
-  deriving (Show, Eq)
+  deriving (Show, Eq, Generic)
+  deriving anyclass (ToJSON)
 
 findWinner :: Int -> [Vote] -> Maybe PowBlockRef
 findWinner _ [] = Nothing
@@ -341,7 +342,7 @@ findWinner m votes =
     (winnerBlock, winnerCount) = maximumBy (comparing swap) countVotes
 
 data WontPushCheckpoint blk = WontPushCheckpoint (Point blk) (Point blk)
-  deriving (Show, Eq)
+  deriving (Show, Eq, Generic)
 
 {-------------------------------------------------------------------------------
    Hard Fork History

--- a/morpho-checkpoint-node/src/Morpho/Node/Env.hs
+++ b/morpho-checkpoint-node/src/Morpho/Node/Env.hs
@@ -94,7 +94,7 @@ withTracing nc action = do
   host <- T.take 8 . fst . T.breakOn "." . T.pack <$> getHostName
   (loggingLayer, loggingFeats) <- loggingFeatures (ncLogging nc) (ncLoggingSwitch nc)
   let basicTrace = setHostname host $ llBasicTrace loggingLayer
-  tracers <- mkTracers basicTrace
+  tracers <- mkTracers nc basicTrace
   runCardanoApplicationWithFeatures loggingFeats $
     CardanoApplication $ action tracers
 

--- a/morpho-checkpoint-node/src/Morpho/Node/Run.hs
+++ b/morpho-checkpoint-node/src/Morpho/Node/Run.hs
@@ -22,7 +22,6 @@ import Control.Monad.Class.MonadSTM.Strict (MonadSTM (atomically), newTVar, read
 import Data.Aeson
 import qualified Data.ByteString.Char8 as BSC
 import Data.Map.Strict (size)
-import Data.Text (pack)
 import Morpho.Common.Socket
 import Morpho.Config.Topology
 import Morpho.Config.Types
@@ -38,7 +37,6 @@ import Morpho.Node.RunNode ()
 import Morpho.RPC.Abstract
 import Morpho.Tracing.Metrics
 import Morpho.Tracing.Tracers
-import Morpho.Tracing.TracingOrphanInstances
 import Morpho.Tracing.Types
 import Network.DNS.Utils (normalize)
 import Network.Socket
@@ -160,8 +158,7 @@ handleSimpleNode pInfo nodeTracers env = do
               { wFingerprint = id,
                 wInitial = Nothing,
                 wReader = ChainDB.getTipPoint chainDB,
-                wNotify = \tip -> do
-                  traceWith (chainTipTracer nodeTracers) (pack $ showPoint NormalVerbosity tip)
+                wNotify = \_ -> do
                   setTimeDiff lastBlockTsVar (mMorphoBlockTime metrics)
               }
         --  Track current block number

--- a/morpho-checkpoint-node/src/Morpho/Tracing/OrphanToJSONInstances.hs
+++ b/morpho-checkpoint-node/src/Morpho/Tracing/OrphanToJSONInstances.hs
@@ -1,0 +1,1129 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Morpho.Tracing.OrphanToJSONInstances where
+
+import Cardano.Crypto.DSIGN.Class
+import Cardano.Crypto.Hash.Class
+import Cardano.Prelude hiding (show)
+import Codec.CBOR.Read (DeserialiseFailure (..))
+import Codec.CBOR.Term
+import Codec.CBOR.Write
+import Control.Monad.Class.MonadTime
+import Data.Aeson (Options (tagSingleConstructors, unwrapUnaryRecords), ToJSON (..), ToJSONKey, Value (..), defaultOptions, genericToJSON, object, (.=))
+import qualified Data.ByteString.Base16 as B16
+import qualified Data.ByteString.Lazy as LBS
+import Data.IP
+import qualified Data.Text as Text
+import qualified GHC.Exts
+import qualified GHC.Stack.Types
+import qualified Morpho.Config.Topology as MT
+import Morpho.Crypto.ECDSASignature
+import Morpho.Ledger.Block
+import Morpho.Ledger.Serialise
+import Morpho.Ledger.SnapshotTimeTravel
+import Morpho.Ledger.State
+import Morpho.Ledger.Update
+import Morpho.Node.RunNode ()
+import Morpho.Tracing.Types
+import Network.DNS.Types
+import Network.Mux (MuxTrace (..), WithMuxBearer (..))
+import Network.Mux.Trace (MuxBearerState (..))
+import Network.Mux.Types
+import qualified Network.Socket as Socket
+import Ouroboros.Consensus.Block
+import Ouroboros.Consensus.BlockchainTime
+import Ouroboros.Consensus.Forecast
+import Ouroboros.Consensus.Fragment.Diff
+import Ouroboros.Consensus.HardFork.History
+import Ouroboros.Consensus.HeaderValidation
+import Ouroboros.Consensus.Ledger.Extended
+import Ouroboros.Consensus.Ledger.Inspect
+import Ouroboros.Consensus.Mempool.API (MempoolSize (..), TraceEventMempool (..))
+import Ouroboros.Consensus.MiniProtocol.BlockFetch.Server (TraceBlockFetchServerEvent (..))
+import Ouroboros.Consensus.MiniProtocol.ChainSync.Client
+  ( ChainSyncClientException (..),
+    ChainSyncClientResult (..),
+    Our (..),
+    Their (..),
+    TraceChainSyncClientEvent (..),
+  )
+import Ouroboros.Consensus.MiniProtocol.ChainSync.Server (TraceChainSyncServerEvent (..))
+import Ouroboros.Consensus.MiniProtocol.LocalTxSubmission.Server (TraceLocalTxSubmissionServerEvent (..))
+import Ouroboros.Consensus.Node.NetworkProtocolVersion
+import Ouroboros.Consensus.Node.Tracers (TraceForgeEvent (..), TraceLabelCreds (..))
+import Ouroboros.Consensus.NodeId
+import Ouroboros.Consensus.Protocol.BFT
+import Ouroboros.Consensus.Storage.ChainDB hiding (InvalidBlock, getTipPoint)
+import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
+import qualified Ouroboros.Consensus.Storage.ChainDB.Impl.Types as ChainDB
+import Ouroboros.Consensus.Storage.FS.API.Types
+import Ouroboros.Consensus.Storage.ImmutableDB hiding (Tip, getTipPoint)
+import qualified Ouroboros.Consensus.Storage.ImmutableDB.API as ImmutableDB
+import qualified Ouroboros.Consensus.Storage.ImmutableDB.Impl.Types as ImmutableDB
+import Ouroboros.Consensus.Storage.LedgerDB.OnDisk
+import qualified Ouroboros.Consensus.Storage.LedgerDB.OnDisk as LedgerDB
+import Ouroboros.Consensus.Storage.Serialisation
+import qualified Ouroboros.Consensus.Storage.VolatileDB.Impl.Types as VolatileDB
+import qualified Ouroboros.Consensus.Util as OCU
+import Ouroboros.Consensus.Util.CBOR
+import Ouroboros.Consensus.Util.Orphans ()
+import qualified Ouroboros.Network.AnchoredFragment as AF
+import qualified Ouroboros.Network.AnchoredSeq as AS
+import Ouroboros.Network.Block (MaxSlotNo, Serialised (..), Tip, getTipPoint)
+import Ouroboros.Network.BlockFetch.ClientState
+import Ouroboros.Network.BlockFetch.Decision
+import Ouroboros.Network.BlockFetch.DeltaQ
+import Ouroboros.Network.Codec (AnyMessageAndAgency (..), PeerHasAgency (..))
+import Ouroboros.Network.Diffusion
+import Ouroboros.Network.Mux
+import Ouroboros.Network.NodeToNode
+import Ouroboros.Network.PeerSelection.LedgerPeers
+import qualified Ouroboros.Network.Protocol.BlockFetch.Type as BlockFetch
+import qualified Ouroboros.Network.Protocol.ChainSync.Type as ChainSync
+import qualified Ouroboros.Network.Protocol.Handshake.Type as Handshake
+import Ouroboros.Network.Protocol.LocalStateQuery.Type
+import qualified Ouroboros.Network.Protocol.Trans.Hello.Type as Hello
+import qualified Ouroboros.Network.Protocol.TxSubmission.Type as TxSubmission
+import Ouroboros.Network.Snocket (FileDescriptor, LocalAddress (..))
+import Ouroboros.Network.Subscription
+import Ouroboros.Network.TxSubmission.Inbound
+  ( ProcessedTxCount (..),
+    TraceTxSubmissionInbound (..),
+  )
+import Ouroboros.Network.TxSubmission.Outbound
+  ( TraceTxSubmissionOutbound (..),
+  )
+import Prelude (show)
+
+deriving instance Generic (TraceBlockchainTimeEvent t)
+
+deriving instance Generic PastHorizonException
+
+deriving instance Generic GHC.Stack.Types.SrcLoc
+
+deriving instance Generic (TraceLabelCreds a)
+
+deriving instance Generic (AF.ChainUpdate blk a)
+
+deriving instance Generic (TraceChainSyncServerEvent blk)
+
+deriving instance Generic (TraceLocalTxSubmissionServerEvent blk)
+
+deriving instance Generic (TraceLabelPeer peer a)
+
+deriving instance Generic (LedgerEvent b)
+
+deriving instance Generic (VolatileDB.ParseError b)
+
+deriving instance Generic ReadIncrementalErr
+
+deriving instance Generic DeserialiseFailure
+
+deriving instance Generic (ImmutableDB.ChunkFileError b)
+
+deriving instance Generic (UnknownRange b)
+
+deriving instance Generic Time
+
+deriving instance Generic (ChainDiff b)
+
+deriving instance Generic (WithIPList a)
+
+deriving instance Generic ConnectResult
+
+deriving instance Generic (LocalAddresses Socket.SockAddr)
+
+deriving instance Generic (WithDomainName a)
+
+deriving instance Generic DnsTrace
+
+deriving instance Generic DNSError
+
+deriving instance Generic MiniProtocolDir
+
+deriving instance Generic MuxSDUHeader
+
+deriving instance Generic MiniProtocolNum
+
+deriving instance Generic RemoteClockModel
+
+deriving instance Generic MuxBearerState
+
+deriving instance Generic (WithAddr a b)
+
+deriving instance Generic ErrorPolicyTrace
+
+deriving instance Generic (TraceSendRecv a)
+
+deriving instance Generic AcceptConnectionsPolicyTrace
+
+deriving instance Generic DiffusionInitializationTracer
+
+deriving instance Generic TraceLedgerPeers
+
+deriving instance Generic PoolStake
+
+deriving instance Generic AccPoolStake
+
+deriving instance Generic RelayAddress
+
+deriving instance Generic DomainAddress
+
+deriving instance Generic (TraceChainSyncClientEvent a)
+
+deriving instance Generic FetchDecline
+
+deriving instance Generic FetchMode
+
+deriving instance Generic (TraceFetchClientState a)
+
+deriving instance Generic (ChainRange pt)
+
+deriving instance Generic (PeerFetchStatus hdr)
+
+deriving instance Generic IsIdle
+
+deriving instance Generic (PeerFetchInFlight a)
+
+deriving instance Generic (FetchRequest a)
+
+deriving instance Generic PeerFetchInFlightLimits
+
+deriving instance Generic (TraceBlockFetchServerEvent blk)
+
+deriving instance Generic (TraceTxSubmissionInbound txid tx)
+
+deriving instance Generic AcquireFailure
+
+deriving instance Generic ProcessedTxCount
+
+deriving instance Generic (TraceTxSubmissionOutbound txid tx)
+
+deriving instance Generic ControlMessage
+
+deriving instance Generic (TraceEventMempool blk)
+
+deriving instance Generic MempoolSize
+
+deriving instance Generic (TraceForgeEvent blk)
+
+deriving instance Generic OutsideForecastRange
+
+deriving instance Generic (Serialised blk)
+
+deriving instance Generic Term
+
+deriving instance Generic NodeToNodeVersion
+
+deriving instance Generic NodeToClientVersion
+
+deriving instance Generic (Handshake.RefuseReason vNumber)
+
+jsonOptions :: Options
+jsonOptions =
+  defaultOptions
+    { tagSingleConstructors = True,
+      unwrapUnaryRecords = True
+    }
+
+instance ToJSON MT.RemoteAddress where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON MorphoInitTrace where
+  toJSON = genericToJSON jsonOptions
+
+deriving newtype instance ToJSON BlockNo
+
+instance ToJSON SafeZone where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON SlotLength where
+  toJSON = String . Text.pack . show . getSlotLength
+
+instance ToJSON EraParams where
+  toJSON = genericToJSON jsonOptions
+
+deriving newtype instance ToJSON RelativeTime
+
+instance ToJSON Bound where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON EraEnd where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON EraSummary where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON GHC.Stack.Types.SrcLoc where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON PastHorizonException where
+  toJSON = genericToJSON jsonOptions
+
+deriving newtype instance ToJSON SystemStart
+
+instance ToJSON DiskSnapshot where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON t => ToJSON (TraceBlockchainTimeEvent t) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON a => ToJSON (TraceLabelCreds a) where
+  toJSON (TraceLabelCreds _ a) = toJSON a
+
+instance ToJSON a => ToJSON (WithOrigin a) where
+  toJSON = genericToJSON jsonOptions
+
+instance (ToJSON peer, ToJSON a) => ToJSON (TraceLabelPeer peer a) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON Ouroboros.Consensus.Storage.FS.API.Types.FsPath where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON DeserialiseFailure where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON ReadIncrementalErr where
+  toJSON = genericToJSON jsonOptions
+
+deriving newtype instance ToJSON VolatileDB.BlockOffset
+
+instance ToJSON IsEBB where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON ChunkNo where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON ImmutableDB.TraceCacheEvent where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON BftValidationErr where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON Time where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON (HeaderHash b) => ToJSON (AF.Anchor b) where
+  toJSON = genericToJSON jsonOptions
+
+instance (ToJSON b, HasHeader b, ToJSON (HeaderHash b)) => ToJSON (ChainDiff b) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON (RealPoint b) => ToJSON (NewTipInfo b) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON ConnectResult where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON (LocalAddresses Socket.SockAddr) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON (WithIPList (SubscriptionTrace Socket.SockAddr)) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON a => ToJSON (WithDomainName a) where
+  toJSON (WithDomainName domain a) =
+    object
+      [ "tag" .= String "WithDomainName",
+        "domain" .= String (decodeUtf8 domain),
+        "value" .= a
+      ]
+
+instance ToJSON DNSError where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON DnsTrace where
+  toJSON = genericToJSON jsonOptions
+
+instance (ToJSON peer, ToJSON a) => ToJSON (WithMuxBearer peer a) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON MiniProtocolDir where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON MiniProtocolNum where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON RemoteClockModel where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON MuxSDUHeader where
+  toJSON = genericToJSON jsonOptions
+
+deriving newtype instance ToJSON CoreNodeId
+
+instance ToJSON MuxBearerState where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON i => ToJSON (ConnectionId i) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON LocalAddress where
+  toJSON = genericToJSON jsonOptions
+
+instance (ToJSON a, ToJSON b) => ToJSON (WithAddr a b) where
+  toJSON = genericToJSON jsonOptions
+
+instance (BftCrypto c, HashAlgorithm h, ToJSON a) => ToJSON (AF.ChainUpdate (MorphoBlock h c) a) where
+  toJSON = genericToJSON jsonOptions
+
+instance (BftCrypto c, HashAlgorithm h) => ToJSON (TraceChainSyncServerEvent (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON (TraceLocalTxSubmissionServerEvent (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON (LedgerEvent (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON (RealPoint (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance Show (HeaderHash blk) => ToJSON (Point blk) where
+  toJSON GenesisPoint = String "GenesisPoint"
+  toJSON (BlockPoint (SlotNo s) h) =
+    object
+      [ "slot" .= s,
+        -- The Show instance for `Hash h a` adds a " at the front and beginning
+        -- And we can't use the ToJSON instance of it because of existential
+        -- quantification in other parts only giving us the Show instance
+        "hash" .= String (Text.filter (/= '"') $ Text.pack (show h))
+      ]
+
+instance (BftCrypto c, HashAlgorithm h) => ToJSON (TraceReplayEvent (MorphoBlock h c) (Point (MorphoBlock h c))) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON (VolatileDB.ParseError (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON (VolatileDB.TraceEvent (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON (ImmutableDB.Tip (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON (ChainHash (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance (BftCrypto c, HashAlgorithm h) => ToJSON (ImmutableDB.ChunkFileError (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance (BftCrypto c, HashAlgorithm h) => ToJSON (ImmutableDB.TraceEvent (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON (LedgerDB.TraceEvent (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON (InitFailure (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance (BftCrypto c, HashAlgorithm h) => ToJSON (StreamFrom (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON (StreamTo (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance (BftCrypto c, HashAlgorithm h) => ToJSON (UnknownRange (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance (BftCrypto c, HashAlgorithm h) => ToJSON (ChainDB.TraceIteratorEvent (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance (BftCrypto c, HashAlgorithm h) => ToJSON (TraceOpenEvent (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON (Tip (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON (HeaderEnvelopeError (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance (BftCrypto c, HashAlgorithm h) => ToJSON (TraceChainSyncClientEvent (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance (BftCrypto c, HashAlgorithm h) => ToJSON (TraceFetchClientState (Header (MorphoBlock h c))) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON (GenTx (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON (TraceEventMempool (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance BftCrypto c => ToJSON (MorphoBlock h c) where
+  toJSON = genericToJSON jsonOptions
+
+instance BftCrypto c => ToJSON (BftFields c (MorphoBlock h c)) where
+  toJSON (BftFields x) = String $ decodeUtf8 $ B16.encode $ toStrictByteString $ encodeSignedDSIGN x
+
+instance (MorphoStateDefaultConstraints h c, Signable (BftDSIGN c) (MorphoStdHeader h c)) => ToJSON (ExtValidationError (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance (MorphoStateDefaultConstraints h c, Signable (BftDSIGN c) (MorphoStdHeader h c), HashAlgorithm h, BftCrypto c, ToJSON (Header (MorphoBlock h c))) => ToJSON (TraceValidationEvent (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON (MorphoStdHeader h c) where
+  toJSON = genericToJSON jsonOptions
+
+instance BftCrypto c => ToJSON (Header (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance (MorphoStateDefaultConstraints h c, Signable (BftDSIGN c) (MorphoStdHeader h c), BftCrypto c, HashAlgorithm h) => ToJSON (TraceInitChainSelEvent (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON (TraceGCEvent (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance (BftCrypto c, HashAlgorithm h) => ToJSON (TraceCopyToImmutableDBEvent (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance (BftCrypto c, HashAlgorithm h) => ToJSON (ChainDB.FollowerRollState (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance (BftCrypto c, HashAlgorithm h) => ToJSON (TraceFollowerEvent (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance (MorphoStateDefaultConstraints h c, Signable (BftDSIGN c) (MorphoStdHeader h c)) => ToJSON (InvalidBlockReason (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON (HeaderFields (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance (MorphoStateDefaultConstraints h c, Signable (BftDSIGN c) (MorphoStdHeader h c), BftCrypto c, HashAlgorithm h) => ToJSON (TraceAddBlockEvent (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance (MorphoStateDefaultConstraints h c, Signable (BftDSIGN c) (MorphoStdHeader h c), BftCrypto c, HashAlgorithm h) => ToJSON (ChainDB.TraceEvent (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON PublicKey where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSONKey PublicKey
+
+instance (BftCrypto c, HashAlgorithm h) => ToJSON (MorphoState (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance (BftCrypto c, HashAlgorithm h) => ToJSON (TimeTravelError (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON MorphoBlockTx where
+  toJSON = genericToJSON jsonOptions
+
+instance (BftCrypto c, HashAlgorithm h) => ToJSON (WontPushCheckpoint (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance (BftCrypto c, HashAlgorithm h) => ToJSON (ExtractStateTrace h c) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON (MorphoError (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON MorphoBody where
+  toJSON = genericToJSON jsonOptions
+
+instance (MorphoStateDefaultConstraints h c, Signable (BftDSIGN c) (MorphoStdHeader h c)) => ToJSON (TraceForgeEvent (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance BftCrypto c => ToJSON (BftFields c (MorphoStdHeader h c)) where
+  toJSON (BftFields x) = String $ decodeUtf8 $ B16.encode $ toStrictByteString $ encodeSignedDSIGN x
+
+instance ToJSON (AnyMessageAndAgency ps) => ToJSON (TraceSendRecv ps) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON (ClientHasAgency (st :: Handshake vNumber vParams)) where
+  toJSON Handshake.TokPropose = "TokPropose"
+
+instance ToJSON (ServerHasAgency (st :: Handshake vNumber vParams)) where
+  toJSON Handshake.TokConfirm = "TokConfirm"
+
+instance
+  (ToJSON vNumber, ToJSONKey vNumber, ToJSON vParams) =>
+  ToJSON (Message (Handshake vNumber vParams) from to)
+  where
+  toJSON (Handshake.MsgProposeVersions versions) =
+    object
+      [ "tag" .= String "MsgProposeVersions",
+        "versions" .= versions
+      ]
+  toJSON (Handshake.MsgAcceptVersion num params) =
+    object
+      [ "tag" .= String "MsgAcceptVersion",
+        "number" .= num,
+        "params" .= params
+      ]
+  toJSON (Handshake.MsgRefuse reason) =
+    object
+      [ "tag" .= String "MsgRefuse",
+        "reason" .= reason
+      ]
+
+instance ToJSON (ClientHasAgency (st :: ChainSync.ChainSync header point tip)) where
+  toJSON ChainSync.TokIdle = "TokIdle"
+
+instance ToJSON (ServerHasAgency (st :: ChainSync.ChainSync header point tip)) where
+  toJSON (ChainSync.TokNext ChainSync.TokCanAwait) = "TokNext TokCanAwait"
+  toJSON (ChainSync.TokNext ChainSync.TokMustReply) = "TokNext TokMustReply"
+  toJSON ChainSync.TokIntersect = "TokIntersect"
+
+instance
+  (ToJSON header, ToJSON point, ToJSON tip) =>
+  ToJSON (Message (ChainSync.ChainSync header point tip) from to)
+  where
+  toJSON ChainSync.MsgRequestNext = object ["tag" .= String "MsgRequestNext"]
+  toJSON ChainSync.MsgAwaitReply = object ["tag" .= String "MsgAwaitReply"]
+  toJSON (ChainSync.MsgRollForward h tip) =
+    object
+      [ "tag" .= String "MsgRollForward",
+        "header" .= h,
+        "tip" .= tip
+      ]
+  toJSON (ChainSync.MsgRollBackward p tip) =
+    object
+      [ "tag" .= String "MsgRollBackward",
+        "point" .= p,
+        "tip" .= tip
+      ]
+  toJSON (ChainSync.MsgFindIntersect ps) =
+    object
+      [ "tag" .= String "MsgFindIntersect",
+        "points" .= ps
+      ]
+  toJSON (ChainSync.MsgIntersectFound p tip) =
+    object
+      [ "tag" .= String "MsgIntersectFound",
+        "point" .= p,
+        "tip" .= tip
+      ]
+  toJSON (ChainSync.MsgIntersectNotFound tip) =
+    object
+      [ "tag" .= String "MsgIntersectNotFound",
+        "tip" .= tip
+      ]
+  toJSON ChainSync.MsgDone = object ["tag" .= String "MsgDone"]
+
+instance ToJSON (ClientHasAgency (st :: BlockFetch.BlockFetch block point)) where
+  toJSON BlockFetch.TokIdle = "TokIdle"
+
+instance ToJSON (ServerHasAgency (st :: BlockFetch.BlockFetch block point)) where
+  toJSON BlockFetch.TokBusy = "TokBusy"
+  toJSON BlockFetch.TokStreaming = "TokStreaming"
+
+instance
+  (ToJSON block, ToJSON point) =>
+  ToJSON (Message (BlockFetch.BlockFetch block point) from to)
+  where
+  toJSON (BlockFetch.MsgRequestRange range) =
+    object
+      [ "tag" .= String "MsgRequestRange",
+        "range" .= range
+      ]
+  toJSON BlockFetch.MsgStartBatch = object ["tag" .= String "MsgStartBatch"]
+  toJSON (BlockFetch.MsgBlock block) =
+    object
+      [ "tag" .= String "MsgBlock",
+        "block" .= block
+      ]
+  toJSON BlockFetch.MsgNoBlocks = object ["tag" .= String "MsgNoBlocks"]
+  toJSON BlockFetch.MsgBatchDone = object ["tag" .= String "MsgBatchDone"]
+  toJSON BlockFetch.MsgClientDone = object ["tag" .= String "MsgClientDone"]
+
+instance BftCrypto c => ToJSON (SerialisedHeader (MorphoBlock h c)) where
+  toJSON (SerialisedHeaderFromDepPair (GenDepPair (NestedCtxt CtxtMorpho) b)) = toJSON b
+
+instance ToJSON (ClientHasAgency (st :: TxSubmission.TxSubmission txid tx)) where
+  toJSON (TxSubmission.TokTxIds TxSubmission.TokBlocking) = "TokTxIds TokBlocking"
+  toJSON (TxSubmission.TokTxIds TxSubmission.TokNonBlocking) = "TokTxIds TokNonBlocking"
+  toJSON TxSubmission.TokTxs = "TokTxs"
+
+instance ToJSON (ServerHasAgency (st :: TxSubmission.TxSubmission txid tx)) where
+  toJSON TxSubmission.TokIdle = "TokIdle"
+
+instance
+  (ToJSON txid, ToJSON tx) =>
+  ToJSON (Message (TxSubmission.TxSubmission txid tx) from to)
+  where
+  toJSON (TxSubmission.MsgRequestTxIds blocking ackCount reqCount) =
+    object
+      [ "tag" .= String "MsgRequestTxIds",
+        "blocking" .= String (Text.pack (show blocking)),
+        "ackCount" .= ackCount,
+        "reqCount" .= reqCount
+      ]
+  toJSON (TxSubmission.MsgReplyTxIds (TxSubmission.BlockingReply txids)) =
+    object
+      [ "tag" .= String "MsgReplyTxIds",
+        "txids" .= txids
+      ]
+  toJSON (TxSubmission.MsgReplyTxIds (TxSubmission.NonBlockingReply txids)) =
+    object
+      [ "tag" .= String "MsgReplyTxIds",
+        "txids" .= txids
+      ]
+  toJSON (TxSubmission.MsgRequestTxs txids) =
+    object
+      [ "tag" .= String "MsgRequestTxs",
+        "txids" .= txids
+      ]
+  toJSON (TxSubmission.MsgReplyTxs txs) =
+    object
+      [ "tag" .= String "MsgReplyTxs",
+        "txs" .= txs
+      ]
+  toJSON TxSubmission.MsgDone =
+    object
+      [ "tag" .= String "MsgDone"
+      ]
+  -- Should be
+  --    toJSON TxSubmission.MsgKThxBye =
+  -- but using _ to prevent deprecation error
+  toJSON _ =
+    object
+      [ "tag" .= String "MsgKThxBye"
+      ]
+
+instance
+  (forall (from' :: ps) (to' :: ps). ToJSON (Message ps from' to')) =>
+  ToJSON (Message (Hello.Hello ps stIdle) from to)
+  where
+  toJSON Hello.MsgHello = object ["tag" .= String "MsgHello"]
+  toJSON (Hello.MsgTalk msg) =
+    object
+      [ "tag" .= String "MsgTalk",
+        "msg" .= msg
+      ]
+
+instance
+  (forall (st' :: ps). ToJSON (ClientHasAgency st')) =>
+  ToJSON (ClientHasAgency (st :: Hello.Hello ps (stIdle :: ps)))
+  where
+  toJSON Hello.TokHello = object ["tag" .= String "TokHello"]
+  toJSON (Hello.TokClientTalk tok) =
+    object
+      [ "tag" .= String "TokClientTalk",
+        "token" .= tok
+      ]
+
+instance
+  (forall (st' :: ps). ToJSON (ServerHasAgency st')) =>
+  ToJSON (ServerHasAgency (st :: Hello.Hello ps stIdle))
+  where
+  toJSON (Hello.TokServerTalk tok) =
+    object
+      [ "tag" .= String "TokServerTalk",
+        "token" .= tok
+      ]
+
+instance ToJSON (Serialised a) where
+  toJSON (Serialised bytes) = toJSON bytes
+
+instance ToJSON Term where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON NodeToClientVersion where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSONKey NodeToClientVersion
+
+instance ToJSON NodeToNodeVersion where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSONKey NodeToNodeVersion
+
+instance ToJSON vNumber => ToJSON (Handshake.RefuseReason vNumber) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON AcceptConnectionsPolicyTrace where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON FileDescriptor where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON DiffusionInitializationTracer where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON PoolStake where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON AccPoolStake where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON IPv6 where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON IPv4 where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON IP where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON DomainAddress where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON RelayAddress where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON TraceLedgerPeers where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON FetchMode where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON FetchDecline where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON pt => ToJSON (ChainRange pt) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON IsIdle where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON (Point hdr) => ToJSON (PeerFetchStatus hdr) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON MaxSlotNo where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON (Point a) => ToJSON (PeerFetchInFlight a) where
+  toJSON = genericToJSON jsonOptions
+
+instance (ToJSON a, ToJSON (HeaderHash a), HasHeader a) => ToJSON (FetchRequest a) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON PeerFetchInFlightLimits where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON (TraceBlockFetchServerEvent blk) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON ProcessedTxCount where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON (TraceTxSubmissionInbound txid tx) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON ControlMessage where
+  toJSON = genericToJSON jsonOptions
+
+instance (ToJSON tx, ToJSON txid) => ToJSON (TraceTxSubmissionOutbound txid tx) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON MempoolSize where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON OutsideForecastRange where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON a => ToJSON (Their a) where
+  toJSON (Their a) = toJSON a
+
+instance ToJSON a => ToJSON (Our a) where
+  toJSON (Our a) = toJSON a
+
+instance
+  ( forall (st' :: ps). ToJSON (ClientHasAgency st'),
+    forall (st' :: ps). ToJSON (ServerHasAgency st')
+  ) =>
+  ToJSON (PeerHasAgency pr (st :: ps))
+  where
+  toJSON (ClientAgency stok) =
+    object
+      [ "tag" .= String "ClientAgency",
+        "contents" .= stok
+      ]
+  toJSON (ServerAgency stok) =
+    object
+      [ "tag" .= String "ServerAgency",
+        "contents" .= stok
+      ]
+
+instance
+  ( forall (st :: ps). ToJSON (ClientHasAgency st),
+    forall (st :: ps). ToJSON (ServerHasAgency st),
+    forall (st :: ps) (st' :: ps). ToJSON (Message ps st st')
+  ) =>
+  ToJSON (AnyMessageAndAgency ps)
+  where
+  toJSON (AnyMessageAndAgency agency msg) = toJSON (agency, msg)
+
+instance ToJSON (OCU.Some a) where
+  toJSON _ = String "Some"
+
+instance ToJSON CallStack where
+  toJSON x = toJSON $ GHC.Exts.toList x
+
+instance ToJSON ByteString where
+  toJSON bs = String $ "0x" <> decodeUtf8 (B16.encode bs)
+
+instance ToJSON LBS.ByteString where
+  toJSON = toJSON . LBS.toStrict
+
+instance (AS.Anchorable v a b, ToJSON a, ToJSON b) => ToJSON (AF.AnchoredSeq v a b) where
+  toJSON (AF.Empty a) = toJSON a
+  toJSON (l AF.:> b) =
+    object
+      [ "rest" .= toJSON l,
+        "top" .= toJSON b
+      ]
+
+instance ToJSON Socket.SockAddr where
+  toJSON = String . Text.pack . show
+
+instance ToJSON PortNumber where
+  toJSON p = Number $ fromIntegral p
+
+instance ToJSON IOException where
+  toJSON e = String $ Text.pack $ displayException e
+
+instance ToJSON SomeException where
+  toJSON e = String $ Text.pack $ displayException e
+
+-- Can't derive an instance for this type because it uses constraints for some constructors
+instance ToJSON (SubscriptionTrace Socket.SockAddr) where
+  toJSON ev =
+    object $
+      ["tag" .= String tag]
+        ++ address
+        ++ extra
+    where
+      tag = case ev of
+        SubscriptionTraceConnectStart _ -> "SubscriptionTraceConnectStart"
+        SubscriptionTraceConnectEnd _ _ -> "SubscriptionTraceConnectEnd"
+        SubscriptionTraceSocketAllocationException _ _ -> "SubscriptionTraceSocketAllocationException"
+        SubscriptionTraceConnectException _ _ -> "SubscriptionTraceConnectException"
+        SubscriptionTraceApplicationException _ _ -> "SubscriptionTraceApplicationException"
+        SubscriptionTraceTryConnectToPeer _ -> "SubscriptionTraceTryConnectToPeer"
+        SubscriptionTraceSkippingPeer _ -> "SubscriptionTraceSkippingPeer"
+        SubscriptionTraceSubscriptionRunning -> "SubscriptionTraceSubscriptionRunning"
+        SubscriptionTraceSubscriptionWaiting _ -> "SubscriptionTraceSubscriptionWaiting"
+        SubscriptionTraceSubscriptionFailed -> "SubscriptionTraceSubscriptionFailed"
+        SubscriptionTraceSubscriptionWaitingNewConnection _ -> "SubscriptionTraceSubscriptionWaitingNewConnection"
+        SubscriptionTraceStart _ -> "SubscriptionTraceStart"
+        SubscriptionTraceRestart {} -> "SubscriptionTraceRestart"
+        SubscriptionTraceConnectionExist _ -> "SubscriptionTraceConnectionExist"
+        SubscriptionTraceUnsupportedRemoteAddr _ -> "SubscriptionTraceUnsupportedRemoteAddr"
+        SubscriptionTraceMissingLocalAddress -> "SubscriptionTraceMissingLocalAddress"
+        SubscriptionTraceAllocateSocket _ -> "SubscriptionTraceAllocateSocket"
+        SubscriptionTraceCloseSocket _ -> "SubscriptionTraceCloseSocket"
+      address = case ev of
+        SubscriptionTraceConnectStart adr -> ["addr" .= toJSON adr]
+        SubscriptionTraceConnectEnd adr _ -> ["addr" .= toJSON adr]
+        SubscriptionTraceSocketAllocationException adr _ -> ["addr" .= toJSON adr]
+        SubscriptionTraceConnectException adr _ -> ["addr" .= toJSON adr]
+        SubscriptionTraceApplicationException adr _ -> ["addr" .= toJSON adr]
+        SubscriptionTraceTryConnectToPeer adr -> ["addr" .= toJSON adr]
+        SubscriptionTraceSkippingPeer adr -> ["addr" .= toJSON adr]
+        SubscriptionTraceSubscriptionRunning -> []
+        SubscriptionTraceSubscriptionWaiting _ -> []
+        SubscriptionTraceSubscriptionFailed -> []
+        SubscriptionTraceSubscriptionWaitingNewConnection _ -> []
+        SubscriptionTraceStart _ -> []
+        SubscriptionTraceRestart {} -> []
+        SubscriptionTraceConnectionExist adr -> ["addr" .= toJSON adr]
+        SubscriptionTraceUnsupportedRemoteAddr adr -> ["addr" .= toJSON adr]
+        SubscriptionTraceMissingLocalAddress -> []
+        SubscriptionTraceAllocateSocket adr -> ["addr" .= toJSON adr]
+        SubscriptionTraceCloseSocket adr -> ["addr" .= toJSON adr]
+      extra = case ev of
+        SubscriptionTraceConnectStart _ -> []
+        SubscriptionTraceConnectEnd _ res ->
+          ["connectionResult" .= toJSON res]
+        SubscriptionTraceSocketAllocationException _ e ->
+          ["exception" .= String (Text.pack $ show e)]
+        SubscriptionTraceConnectException _ e ->
+          ["exception" .= String (Text.pack $ show e)]
+        SubscriptionTraceApplicationException _ e ->
+          ["exception" .= String (Text.pack $ show e)]
+        SubscriptionTraceTryConnectToPeer _ -> []
+        SubscriptionTraceSkippingPeer _ -> []
+        SubscriptionTraceSubscriptionRunning -> []
+        SubscriptionTraceSubscriptionWaiting count -> ["numberWaitingOn" .= toJSON count]
+        SubscriptionTraceSubscriptionFailed -> []
+        SubscriptionTraceSubscriptionWaitingNewConnection delay ->
+          ["waitingBeforeAttemptingNewConnection" .= toJSON delay]
+        SubscriptionTraceStart val -> ["valency" .= toJSON val]
+        SubscriptionTraceRestart delay valDes valCur ->
+          [ "restartAfter" .= toJSON delay,
+            "currentValency" .= toJSON valCur,
+            "desiredValency" .= toJSON valDes
+          ]
+        SubscriptionTraceConnectionExist _ -> []
+        SubscriptionTraceUnsupportedRemoteAddr _ -> []
+        SubscriptionTraceMissingLocalAddress -> []
+        SubscriptionTraceAllocateSocket _ -> []
+        SubscriptionTraceCloseSocket _ -> []
+
+instance ToJSON MuxTrace where
+  toJSON ev =
+    object
+      [ "tag" .= String tag,
+        "contents" .= contents
+      ]
+    where
+      tag = case ev of
+        MuxTraceRecvHeaderStart -> "MuxTraceRecvHeaderStart"
+        MuxTraceRecvHeaderEnd _ -> "MuxTraceRecvHeaderEnd"
+        MuxTraceRecvDeltaQObservation _ _ -> "MuxTraceRecvDeltaQObservation"
+        MuxTraceRecvDeltaQSample {} -> "MuxTraceRecvDeltaQSample"
+        MuxTraceRecvStart _ -> "MuxTraceRecvStart"
+        MuxTraceRecvEnd _ -> "MuxTraceRecvEnd"
+        MuxTraceSendStart _ -> "MuxTraceSendStart"
+        MuxTraceSendEnd -> "MuxTraceSendEnd"
+        MuxTraceState _ -> "MuxTraceState"
+        MuxTraceCleanExit _ _ -> "MuxTraceCleanExit"
+        MuxTraceExceptionExit {} -> "MuxTraceExceptionExit"
+        MuxTraceChannelRecvStart _ -> "MuxTraceChannelRecvStart"
+        MuxTraceChannelRecvEnd _ _ -> "MuxTraceChannelRecvEnd"
+        MuxTraceChannelSendStart _ _ -> "MuxTraceChannelSendStart"
+        MuxTraceChannelSendEnd _ -> "MuxTraceChannelSendEnd"
+        MuxTraceHandshakeStart -> "MuxTraceHandshakeStart"
+        MuxTraceHandshakeClientEnd _ -> "MuxTraceHandshakeClientEnd"
+        MuxTraceHandshakeServerEnd -> "MuxTraceHandshakeServerEnd"
+        MuxTraceHandshakeClientError _ _ -> "MuxTraceHandshakeClientError"
+        MuxTraceHandshakeServerError _ -> "MuxTraceHandshakeServerError"
+        MuxTraceSDUReadTimeoutException -> "MuxTraceSDUReadTimeoutException"
+        MuxTraceSDUWriteTimeoutException -> "MuxTraceSDUWriteTimeoutException"
+        MuxTraceStartEagerly _ _ -> "MuxTraceStartEagerly"
+        MuxTraceStartOnDemand _ _ -> "MuxTraceStartOnDemand"
+        MuxTraceStartedOnDemand _ _ -> "MuxTraceStartedOnDemand"
+        MuxTraceTerminating _ _ -> "MuxTraceTerminating"
+        MuxTraceShutdown -> "MuxTraceShutdown"
+
+      contents = case ev of
+        MuxTraceRecvHeaderStart -> []
+        MuxTraceRecvHeaderEnd v1 -> [toJSON v1]
+        MuxTraceRecvDeltaQObservation v1 v2 -> [toJSON v1, toJSON v2]
+        MuxTraceRecvDeltaQSample v1 v2 v3 v4 v5 v6 v7 v8 -> [toJSON v1, toJSON v2, toJSON v3, toJSON v4, toJSON v5, toJSON v6, toJSON v7, toJSON v8]
+        MuxTraceRecvStart v1 -> [toJSON v1]
+        MuxTraceRecvEnd v1 -> [toJSON v1]
+        MuxTraceSendStart v1 -> [toJSON v1]
+        MuxTraceSendEnd -> []
+        MuxTraceState v1 -> [toJSON v1]
+        MuxTraceCleanExit v1 v2 -> [toJSON v1, toJSON v2]
+        MuxTraceExceptionExit v1 v2 v3 -> [toJSON v1, toJSON v2, toJSON v3]
+        MuxTraceChannelRecvStart v1 -> [toJSON v1]
+        MuxTraceChannelRecvEnd v1 v2 -> [toJSON v1, toJSON v2]
+        MuxTraceChannelSendStart v1 v2 -> [toJSON v1, toJSON v2]
+        MuxTraceChannelSendEnd v1 -> [toJSON v1]
+        MuxTraceHandshakeStart -> []
+        MuxTraceHandshakeClientEnd v1 -> [toJSON v1]
+        MuxTraceHandshakeServerEnd -> []
+        MuxTraceHandshakeClientError v1 v2 -> [toJSON (SomeException v1), toJSON v2]
+        MuxTraceHandshakeServerError v1 -> [toJSON (SomeException v1)]
+        MuxTraceSDUReadTimeoutException -> []
+        MuxTraceSDUWriteTimeoutException -> []
+        MuxTraceStartEagerly v1 v2 -> [toJSON v1, toJSON v2]
+        MuxTraceStartOnDemand v1 v2 -> [toJSON v1, toJSON v2]
+        MuxTraceStartedOnDemand v1 v2 -> [toJSON v1, toJSON v2]
+        MuxTraceTerminating v1 v2 -> [toJSON v1, toJSON v2]
+        MuxTraceShutdown -> []
+
+instance ToJSON ErrorPolicyTrace where
+  toJSON ev =
+    object
+      [ "tag" .= String tag,
+        "contents" .= contents
+      ]
+    where
+      tag = case ev of
+        ErrorPolicySuspendPeer {} -> "ErrorPolicySuspendPeer"
+        ErrorPolicySuspendConsumer _ _ -> "ErrorPolicySuspendConsumer"
+        ErrorPolicyLocalNodeError _ -> "ErrorPolicyLocalNodeError"
+        ErrorPolicyResumePeer -> "ErrorPolicyResumePeer"
+        ErrorPolicyKeepSuspended -> "ErrorPolicyKeepSuspended"
+        ErrorPolicyResumeConsumer -> "ErrorPolicyResumeConsumer"
+        ErrorPolicyResumeProducer -> "ErrorPolicyResumeProducer"
+        ErrorPolicyUnhandledApplicationException _ -> "ErrorPolicyUnhandledApplicationException"
+        ErrorPolicyUnhandledConnectionException _ -> "ErrorPolicyUnhandledConnectionException"
+        ErrorPolicyAcceptException _ -> "ErrorPolicyAcceptException"
+      contents = case ev of
+        ErrorPolicySuspendPeer _ v2 v3 -> [toJSON v2, toJSON v3]
+        ErrorPolicySuspendConsumer _ v2 -> [toJSON v2]
+        ErrorPolicyLocalNodeError _ -> []
+        ErrorPolicyResumePeer -> []
+        ErrorPolicyKeepSuspended -> []
+        ErrorPolicyResumeConsumer -> []
+        ErrorPolicyResumeProducer -> []
+        ErrorPolicyUnhandledApplicationException e -> [toJSON e]
+        ErrorPolicyUnhandledConnectionException e -> [toJSON e]
+        ErrorPolicyAcceptException e -> [toJSON e]
+
+instance ToJSON ChainSyncClientResult where
+  toJSON (ForkTooDeep int (Our our) (Their their)) =
+    object
+      [ "tag" .= String "ForkTooDeep",
+        "intersection" .= int,
+        "ourTip" .= getTipPoint our,
+        "theirTip" .= getTipPoint their
+      ]
+  toJSON (NoMoreIntersection (Our our) (Their their)) =
+    object
+      [ "tag" .= String "NoMoreIntersection",
+        "ourTip" .= getTipPoint our,
+        "theirTip" .= getTipPoint their
+      ]
+  toJSON (RolledBackPastIntersection rollbackPoint (Our our) (Their their)) =
+    object
+      [ "tag" .= String "RolledBackPastIntersection",
+        "rollbackPoint" .= rollbackPoint,
+        "ourTip" .= getTipPoint our,
+        "theirTip" .= getTipPoint their
+      ]
+  toJSON AskedToTerminate =
+    object
+      [ "tag" .= String "AskedToTerminate"
+      ]
+
+instance (BlockSupportsProtocol blk, ValidateEnvelope blk) => ToJSON (HeaderError blk) where
+  toJSON (HeaderProtocolError validationErr) =
+    object
+      [ "tag" .= String "HeaderProtocolError",
+        "err" .= String (Text.pack $ show validationErr)
+      ]
+  toJSON (HeaderEnvelopeError envelopeErr) =
+    object
+      [ "tag" .= String "HeaderEnvelopeError",
+        "err" .= String (Text.pack $ show envelopeErr)
+      ]
+
+instance ToJSON ChainSyncClientException where
+  toJSON (HeaderError pt er (Our our) (Their their)) =
+    object
+      [ "tag" .= String "HeaderError",
+        "invalidHeader" .= pt,
+        "error" .= toJSON er,
+        "ourTip" .= getTipPoint our,
+        "theirTip" .= getTipPoint their
+      ]
+  toJSON (InvalidIntersection int (Our our) (Their their)) =
+    object
+      [ "tag" .= String "InvalidIntersection",
+        "intersection" .= int,
+        "ourTip" .= getTipPoint our,
+        "theirTip" .= getTipPoint their
+      ]
+  toJSON (DoesntFit received expected (Our our) (Their their)) =
+    object
+      [ "tag" .= String "DoesntFit",
+        "received" .= String (Text.pack $ show received),
+        "expected" .= String (Text.pack $ show expected),
+        "ourTip" .= getTipPoint our,
+        "theirTip" .= getTipPoint their
+      ]
+  toJSON (InvalidBlock pt reason) =
+    object
+      [ "tag" .= String "InvalidBlock",
+        "received" .= pt,
+        "reason" .= String (Text.pack $ show reason)
+      ]

--- a/morpho-checkpoint-node/src/Morpho/Tracing/Tracers.hs
+++ b/morpho-checkpoint-node/src/Morpho/Tracing/Tracers.hs
@@ -90,6 +90,7 @@ data Tracers peer localPeer h c = Tracers
 mkTracers ::
   forall peer localPeer blk h c.
   ( Show peer,
+    ToJSON peer,
     MorphoStateDefaultConstraints h c,
     blk ~ MorphoBlock h c,
     Signable (BftDSIGN c) (MorphoStdHeader h c),
@@ -210,6 +211,7 @@ mkTracers tracer = do
 
 nodeToNodeTracers' ::
   ( Show peer,
+    ToJSON peer,
     MorphoStateDefaultConstraints h c,
     blk ~ MorphoBlock h c
   ) =>

--- a/morpho-checkpoint-node/src/Morpho/Tracing/Tracers.hs
+++ b/morpho-checkpoint-node/src/Morpho/Tracing/Tracers.hs
@@ -83,6 +83,12 @@ data Tracers peer localPeer h c = Tracers
     ledgerPeersTracer :: Tracer IO TraceLedgerPeers
   }
 
+-- Logs a traversable by logging each item separately
+-- Copied from co-log-core:
+-- https://hackage.haskell.org/package/co-log-core-0.2.1.1/docs/Colog-Core-Action.html#v:separate
+separate :: (Traversable f, Applicative m) => Tracer m msg -> Tracer m (f msg)
+separate (Tracer action) = Tracer (traverse_ action)
+
 -- | Generates all the tracers necessary for the checkpointing node.
 --
 -- Note: the constraint on the morpho block is necessary for the
@@ -173,8 +179,9 @@ mkTracers tracer = do
             toLogObject $
               appendName "chain-sync-server-block" ctracer,
           Consensus.blockFetchDecisionTracer =
-            toLogObject $
-              appendName "block-fetch-decision" ctracer,
+            separate $
+              toLogObject $
+                appendName "block-fetch-decision" ctracer,
           Consensus.blockFetchClientTracer =
             toLogObject $
               appendName "block-fetch-client" ctracer,

--- a/morpho-checkpoint-node/src/Morpho/Tracing/TracingOrphanInstances.hs
+++ b/morpho-checkpoint-node/src/Morpho/Tracing/TracingOrphanInstances.hs
@@ -268,6 +268,10 @@ instance HasPrivacyAnnotation (TraceChainSyncServerEvent blk)
 instance HasSeverityAnnotation (TraceChainSyncServerEvent blk) where
   getSeverityAnnotation _ = Info
 
+instance HasSeverityAnnotation (Either FetchDecline [Point (Header blk)])
+
+instance HasPrivacyAnnotation (Either FetchDecline [Point (Header blk)])
+
 instance HasPrivacyAnnotation (TraceEventMempool blk)
 
 instance HasSeverityAnnotation MorphoTransactionError where

--- a/morpho-checkpoint-node/src/Morpho/Tracing/Types.hs
+++ b/morpho-checkpoint-node/src/Morpho/Tracing/Types.hs
@@ -10,7 +10,6 @@ where
 import Cardano.BM.Data.Severity
 import Cardano.BM.Data.Tracer
 import Cardano.Prelude
-import Data.Aeson hiding (Error)
 import Morpho.Config.Topology
 import Morpho.Ledger.Block
 import Morpho.Ledger.State
@@ -31,31 +30,6 @@ instance HasSeverityAnnotation MorphoInitTrace where
   getSeverityAnnotation PrometheusException {} = Error
 
 instance HasPrivacyAnnotation MorphoInitTrace
-
-instance Transformable Text IO MorphoInitTrace where
-  trTransformer = trStructuredText
-
-instance ToObject MorphoInitTrace where
-  toObject _ (NotFoundInTopology nid) =
-    mkObject
-      [ "kind" .= String "NotFoundInTopology",
-        "nodeId" .= String (show nid)
-      ]
-  toObject _ (ProducerList nid prods) =
-    mkObject
-      [ "kind" .= String "ProducerList",
-        "nodeId" .= String (show nid),
-        "producers" .= String (show prods)
-      ]
-  toObject _ PerformingDBValidation =
-    mkObject
-      [ "kind" .= String "PerformingDBValidation"
-      ]
-  toObject _ (PrometheusException err) =
-    mkObject
-      [ "kind" .= String "PrometheusException",
-        "error" .= String (show err)
-      ]
 
 instance HasTextFormatter MorphoInitTrace where
   formatText (NotFoundInTopology nid) _ = "Own node id " <> show nid <> " not found in topology"

--- a/morpho-checkpoint-node/src/Morpho/Tracing/Types.hs
+++ b/morpho-checkpoint-node/src/Morpho/Tracing/Types.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE MultiParamTypeClasses #-}
 
 module Morpho.Tracing.Types
@@ -21,7 +22,7 @@ data MorphoInitTrace
   | ProducerList CoreNodeId [RemoteAddress]
   | PerformingDBValidation
   | PrometheusException IOException
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic)
 
 instance HasSeverityAnnotation MorphoInitTrace where
   getSeverityAnnotation NotFoundInTopology {} = Error
@@ -67,4 +68,4 @@ data ExtractStateTrace h c
   = MorphoStateTrace (MorphoState (MorphoBlock h c))
   | VoteErrorTrace VoteError
   | WontPushCheckpointTrace (WontPushCheckpoint (MorphoBlock h c))
-  deriving (Eq, Show)
+  deriving (Eq, Show, Generic)

--- a/morpho-checkpoint-node/src/Morpho/Tracing/Verbosity.hs
+++ b/morpho-checkpoint-node/src/Morpho/Tracing/Verbosity.hs
@@ -48,7 +48,9 @@ limitRecursion n (Array xs)
   | n <= 0 = (Any True, String "[ ... ]")
   | otherwise =
     -- Also uses above-described Applicative instance
-    second Array $ traverse (limitRecursion (n - 1)) xs
+    -- We don't decrease n here because JSON lists are pretty slim. We're
+    -- mainly just concerned about objects for the recursion
+    second Array $ traverse (limitRecursion n) xs
 limitRecursion _ v = (Any False, v)
 
 class MinLogRecursion a where

--- a/morpho-checkpoint-node/src/Morpho/Tracing/Verbosity.hs
+++ b/morpho-checkpoint-node/src/Morpho/Tracing/Verbosity.hs
@@ -1,0 +1,151 @@
+{-# LANGUAGE FlexibleInstances #-}
+
+module Morpho.Tracing.Verbosity where
+
+import Cardano.Prelude
+import Data.Aeson
+import Morpho.Ledger.Block
+import Morpho.Ledger.SnapshotTimeTravel
+import Morpho.RPC.Abstract
+import Morpho.Tracing.Types
+import Network.Mux
+import qualified Network.Socket as Socket
+import Ouroboros.Consensus.BlockchainTime
+import Ouroboros.Consensus.Mempool
+import Ouroboros.Consensus.MiniProtocol.BlockFetch.Server
+import Ouroboros.Consensus.MiniProtocol.ChainSync.Client
+  ( TraceChainSyncClientEvent,
+  )
+import Ouroboros.Consensus.MiniProtocol.ChainSync.Server
+  ( TraceChainSyncServerEvent (..),
+  )
+import Ouroboros.Consensus.MiniProtocol.LocalTxSubmission.Server
+import Ouroboros.Consensus.Node.Tracers (TraceForgeEvent, TraceLabelCreds (..))
+import qualified Ouroboros.Consensus.Storage.ChainDB.Impl.Types as ChainDB
+import Ouroboros.Network.BlockFetch
+import Ouroboros.Network.Diffusion
+import Ouroboros.Network.NodeToNode
+import Ouroboros.Network.PeerSelection.LedgerPeers
+import Ouroboros.Network.TxSubmission.Inbound
+import Ouroboros.Network.TxSubmission.Outbound
+  ( TraceTxSubmissionOutbound (..),
+  )
+
+-- | Limits the recursion depth of the given 'Value' to the specified 'Int'
+-- When the recursion depth is reached, a JSON object is replaced with the
+-- string @{ ... }@, while a JSON list is replaced with the string @[ ... ]@
+-- Also returned is an 'Any' value representing whether any such recursion
+-- limiting was done
+limitRecursion :: Int -> Value -> (Any, Value)
+limitRecursion n (Object xs)
+  | n <= 0 = (Any True, String "{ ... }")
+  | otherwise =
+    -- This uses the Applicative instance
+    --   Monoid a => Applicative ((,) a)
+    -- with a ~ Any for the traverse
+    second Object $ traverse (limitRecursion (n - 1)) xs
+limitRecursion n (Array xs)
+  | n <= 0 = (Any True, String "[ ... ]")
+  | otherwise =
+    -- Also uses above-described Applicative instance
+    second Array $ traverse (limitRecursion (n - 1)) xs
+limitRecursion _ v = (Any False, v)
+
+class MinLogRecursion a where
+  minLogRecursion :: a -> Int
+
+instance MinLogRecursion a => MinLogRecursion (WithIPList a) where
+  minLogRecursion (WithIPList _ _ a) = 1 + minLogRecursion a
+
+instance MinLogRecursion a => MinLogRecursion (WithDomainName a) where
+  minLogRecursion (WithDomainName _ a) = 1 + minLogRecursion a
+
+instance MinLogRecursion a => MinLogRecursion (WithMuxBearer peer a) where
+  minLogRecursion (WithMuxBearer _ a) = 1 + minLogRecursion a
+
+instance MinLogRecursion a => MinLogRecursion (WithAddr peer a) where
+  minLogRecursion (WithAddr _ a) = 1 + minLogRecursion a
+
+instance MinLogRecursion a => MinLogRecursion (TraceLabelPeer peer a) where
+  minLogRecursion (TraceLabelPeer _ a) = 1 + minLogRecursion a
+
+instance MinLogRecursion a => MinLogRecursion (TraceLabelCreds a) where
+  minLogRecursion (TraceLabelCreds _ a) = minLogRecursion a
+
+instance MinLogRecursion MorphoInitTrace where
+  minLogRecursion _ = 10
+
+instance MinLogRecursion (ExtractStateTrace h c) where
+  minLogRecursion _ = 10
+
+instance MinLogRecursion (ChainDB.TraceAddBlockEvent (MorphoBlock h c)) where
+  minLogRecursion ChainDB.AddedToCurrentChain {} = 4
+  minLogRecursion ChainDB.SwitchedToAFork {} = 4
+  minLogRecursion _ = 10
+
+instance MinLogRecursion (ChainDB.TraceEvent (MorphoBlock h c)) where
+  minLogRecursion (ChainDB.TraceAddBlockEvent x) = 1 + minLogRecursion x
+  minLogRecursion _ = 10
+
+instance MinLogRecursion (SubscriptionTrace Socket.SockAddr) where
+  minLogRecursion _ = 10
+
+instance MinLogRecursion DnsTrace where
+  minLogRecursion _ = 10
+
+instance MinLogRecursion MuxTrace where
+  minLogRecursion _ = 10
+
+instance MinLogRecursion ErrorPolicyTrace where
+  minLogRecursion _ = 10
+
+instance MinLogRecursion (RpcTrace e i o) where
+  minLogRecursion _ = 10
+
+instance MinLogRecursion (TimeTravelError blk) where
+  minLogRecursion _ = 10
+
+instance MinLogRecursion (TraceSendRecv a) where
+  minLogRecursion _ = 10
+
+instance MinLogRecursion AcceptConnectionsPolicyTrace where
+  minLogRecursion _ = 10
+
+instance MinLogRecursion DiffusionInitializationTracer where
+  minLogRecursion _ = 10
+
+instance MinLogRecursion TraceLedgerPeers where
+  minLogRecursion _ = 10
+
+instance MinLogRecursion (TraceChainSyncClientEvent blk) where
+  minLogRecursion _ = 10
+
+instance MinLogRecursion (TraceChainSyncServerEvent blk) where
+  minLogRecursion _ = 10
+
+instance MinLogRecursion (FetchDecision a) where
+  minLogRecursion _ = 10
+
+instance MinLogRecursion (TraceFetchClientState blk) where
+  minLogRecursion _ = 10
+
+instance MinLogRecursion (TraceBlockFetchServerEvent blk) where
+  minLogRecursion _ = 10
+
+instance MinLogRecursion (TraceTxSubmissionInbound txid tx) where
+  minLogRecursion _ = 10
+
+instance MinLogRecursion (TraceTxSubmissionOutbound txid tx) where
+  minLogRecursion _ = 10
+
+instance MinLogRecursion (TraceLocalTxSubmissionServerEvent blk) where
+  minLogRecursion _ = 10
+
+instance MinLogRecursion (TraceEventMempool blk) where
+  minLogRecursion _ = 10
+
+instance MinLogRecursion (TraceForgeEvent blk) where
+  minLogRecursion _ = 10
+
+instance MinLogRecursion (TraceBlockchainTimeEvent t) where
+  minLogRecursion _ = 10

--- a/morpho-checkpoint-node/tests/Test/Morpho/Examples.hs
+++ b/morpho-checkpoint-node/tests/Test/Morpho/Examples.hs
@@ -203,6 +203,7 @@ exampleNodeConfig =
       ncNodeHost = NodeHostAddress (Just "127.0.0.1"),
       ncNodePort = 2345,
       ncValidateDb = True,
+      ncVerbosity = 2,
       ncLogging =
         Representation
           { minSeverity = Info,

--- a/morpho-checkpoint-node/tests/Test/Morpho/Tracing.hs
+++ b/morpho-checkpoint-node/tests/Test/Morpho/Tracing.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE DeriveGeneric #-}
+
+module Test.Morpho.Tracing (traceTests) where
+
+import Cardano.Prelude
+import Data.Aeson
+import Morpho.Tracing.Verbosity
+import Test.Morpho.Generators ()
+import Test.QuickCheck
+import Test.Tasty
+import Test.Tasty.QuickCheck
+
+traceTests :: TestTree
+traceTests =
+  testGroup
+    "Tracing"
+    [ testGroup
+        "LimitRecursion"
+        [ testProperty "IfLimited" returnsIfLimited,
+          testProperty "LimitDepth" limitDepth
+        ]
+    ]
+
+returnsIfLimited :: Property
+returnsIfLimited = property $ \limit value ->
+  let (Any didLimit, limited) = limitRecursion limit value
+   in didLimit /= (value == limited)
+
+valueDepth :: Value -> Int
+valueDepth (Object xs) = 1 + maximum (map valueDepth xs)
+valueDepth (Array xs) = 1 + maximum (map valueDepth xs)
+valueDepth _ = 0
+
+limitDepth :: Property
+limitDepth = forAll (suchThat arbitrary (>= 0)) $ \limit ->
+  property $ \value -> valueDepth (snd $ limitRecursion limit value) <= limit

--- a/morpho-checkpoint-node/tests/Test/Morpho/Tracing.hs
+++ b/morpho-checkpoint-node/tests/Test/Morpho/Tracing.hs
@@ -29,7 +29,7 @@ returnsIfLimited = property $ \limit value ->
 
 valueDepth :: Value -> Int
 valueDepth (Object xs) = 1 + maximum (map valueDepth xs)
-valueDepth (Array xs) = 1 + maximum (map valueDepth xs)
+valueDepth (Array xs) = 0 + maximum (map valueDepth xs)
 valueDepth _ = 0
 
 limitDepth :: Property

--- a/morpho-checkpoint-node/tests/configuration/Golden/Config.yaml
+++ b/morpho-checkpoint-node/tests/configuration/Golden/Config.yaml
@@ -31,6 +31,8 @@ NodeHost: "127.0.0.1"
 NodePort: 2345
 ValidateDatabase: True
 
+Verbosity: 2
+
 #####         Tracing         #####
 Logging:
   minSeverity: Info

--- a/morpho-checkpoint-node/tests/test.hs
+++ b/morpho-checkpoint-node/tests/test.hs
@@ -4,6 +4,7 @@ import Test.Morpho.Crypto.ECDSASignature
 import Test.Morpho.Golden
 import Test.Morpho.Ledger.State
 import Test.Morpho.Serialisation
+import Test.Morpho.Tracing
 import Test.Tasty
 import Prelude
 
@@ -21,5 +22,6 @@ tests = do
         utilsTests,
         serialiseTests,
         goldenTests,
-        configTests
+        configTests,
+        traceTests
       ]


### PR DESCRIPTION
Previously, in order to trace structural JSON values, the conversions from Haskell values to JSON values was done with manually written `ToObject` instances. While automatically derived `ToJSON` instances could have been used instead (and that's what the first commit does), the problem then is that the resulting JSON values can get arbitrarily big, resulting in log lines that span thousands of bytes (see #17).

In order to control this, a further commit introduces the `MinLogRecursion` class, which given a value, gives a number for how deep it should be recursed into.