### PR TITLE
Only pass the checkpointed block to getLatestBlock instead of full checkpoint

### DIFF
--- a/morpho-checkpoint-node/src/Morpho/Node/Run.hs
+++ b/morpho-checkpoint-node/src/Morpho/Node/Run.hs
@@ -249,7 +249,7 @@ requestCurrentBlock ::
 requestCurrentBlock kernel env nodeTracers metrics = forever $ do
   threadDelay (ePoWBlockFetchInterval env)
   st <- atomically $ morphoLedgerState . ledgerState <$> ChainDB.getCurrentLedger chainDB
-  rpcCall (powNodeRpcTracer nodeTracers) (eRpcUpstream env) GetLatestBlock (eCheckpointingInterval env, lastCheckpoint st) processResponse
+  rpcCall (powNodeRpcTracer nodeTracers) (eRpcUpstream env) GetLatestBlock (eCheckpointingInterval env, checkpointedBlock (lastCheckpoint st)) processResponse
   where
     processResponse :: Maybe PowBlockRef -> IO ()
     processResponse Nothing = return ()

--- a/morpho-checkpoint-node/src/Morpho/RPC/Abstract.hs
+++ b/morpho-checkpoint-node/src/Morpho/RPC/Abstract.hs
@@ -24,7 +24,7 @@ import Prelude (show)
 -- @i@ is the input type, @o@ the output type
 data RpcMethod i o where
   -- | Get the latest checkpoint candidate block
-  GetLatestBlock :: RpcMethod (Int, Checkpoint) (Maybe PowBlockRef)
+  GetLatestBlock :: RpcMethod (Int, PowBlockRef) (Maybe PowBlockRef)
   -- | Push a checkpoint to the Pow chain
   PushCheckpoint :: RpcMethod Checkpoint Bool
 

--- a/morpho-checkpoint-node/src/Morpho/RPC/JsonRpcProtocol.hs
+++ b/morpho-checkpoint-node/src/Morpho/RPC/JsonRpcProtocol.hs
@@ -33,7 +33,7 @@ data JsonRpcMethod o = JsonRpcMethod
   }
 
 jsonRpcMethod :: RpcMethod i o -> i -> JsonRpcMethod o
-jsonRpcMethod GetLatestBlock (k, Checkpoint {checkpointedBlock = PowBlockRef {powBlockHash}}) =
+jsonRpcMethod GetLatestBlock (k, PowBlockRef {powBlockHash}) =
   JsonRpcMethod
     { methodName = "checkpointing_getLatestBlock",
       methodParams = [toJSON k, toJSON (JsonRpcBlockHash <$> hash)],


### PR DESCRIPTION
This mainly just simplifies the JSON trace messages, since it removes
all the irrelevant checkpoint fields not needed for this RPC method