### PR TITLE
Update and expose mantis version from flake

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,5 +1,20 @@
 {
   "nodes": {
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1614513358,
+        "narHash": "sha256-LakhOx3S1dRjnh0b5Dg3mbZyH0ToC9I8Y2wKSkBaTzU=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5466c5bbece17adaab2d82fae80b46e807611bf3",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
     "haskell-nix": {
       "inputs": {
         "nixpkgs": "nixpkgs",
@@ -18,6 +33,27 @@
       "original": {
         "owner": "input-output-hk",
         "repo": "haskell.nix",
+        "type": "github"
+      }
+    },
+    "mantis": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs_2",
+        "sbt-derivation": "sbt-derivation"
+      },
+      "locked": {
+        "lastModified": 1618579597,
+        "narHash": "sha256-U9l0Nj6cDY7pGuGhqEAGUKlNyxRATuTypQibo7aepIk=",
+        "owner": "input-output-hk",
+        "repo": "mantis",
+        "rev": "00a44422cd9a8ade2c6a93859cd369b6f1b0225b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "input-output-hk",
+        "repo": "mantis",
+        "rev": "00a44422cd9a8ade2c6a93859cd369b6f1b0225b",
         "type": "github"
       }
     },
@@ -85,10 +121,42 @@
         "type": "github"
       }
     },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1610118011,
+        "narHash": "sha256-a17vwGBOqmAsy/Wkvf10ygDyfgjJpvlPyNnf7SAk+Ac=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "a98302aa9b9628915878a6ea9776c40a0bb02950",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "a98302aa9b9628915878a6ea9776c40a0bb02950",
+        "type": "github"
+      }
+    },
     "root": {
       "inputs": {
         "haskell-nix": "haskell-nix",
+        "mantis": "mantis",
         "utils": "utils"
+      }
+    },
+    "sbt-derivation": {
+      "locked": {
+        "lastModified": 1602145051,
+        "narHash": "sha256-P71MgJhJoTYba/5fI5xYeKuh/dpQuqlXp3REArciJ58=",
+        "owner": "zaninime",
+        "repo": "sbt-derivation",
+        "rev": "9666b2b589ed68823fff1cefa4cd8a8ab54956c1",
+        "type": "github"
+      },
+      "original": {
+        "owner": "zaninime",
+        "repo": "sbt-derivation",
+        "type": "github"
       }
     },
     "utils": {


### PR DESCRIPTION
This allows installing a Morpho-compatible Mantis with

```
nix profile install github:input-output-hk/ECIP-Checkpointing#mantis
```

Or using this PR's branch:

```
nix profile install github:input-output-hk/ECIP-Checkpointing/expose-mantis#mantis
```