### PR TITLE
Faster compilation times by isolating external orphan ToJSONInstances

### DIFF
--- a/morpho-checkpoint-node/morpho-checkpoint-node.cabal
+++ b/morpho-checkpoint-node/morpho-checkpoint-node.cabal
@@ -39,12 +39,13 @@ library
         Morpho.RPC.JsonRpc
         Morpho.RPC.JsonRpcProtocol
         Morpho.Tracing.Pretty
-        Morpho.Tracing.OrphanToJSONInstances
-        Morpho.Tracing.TracingOrphanInstances
         Morpho.Tracing.Types
         Morpho.Tracing.Tracers
         Morpho.Tracing.Metrics
         Morpho.Tracing.Verbosity
+        Morpho.Tracing.Orphan.MorphoToJSONInstances
+        Morpho.Tracing.Orphan.ExternalToJSONInstances
+        Morpho.Tracing.Orphan.TracingInstances
 
     hs-source-dirs:     src
     default-language:   Haskell2010

--- a/morpho-checkpoint-node/src/Morpho/Config/Combined.hs
+++ b/morpho-checkpoint-node/src/Morpho/Config/Combined.hs
@@ -1,7 +1,5 @@
-{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE NamedFieldPuns #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TypeOperators #-}
 
 module Morpho.Config.Combined where
 

--- a/morpho-checkpoint-node/src/Morpho/Config/Orphans.hs
+++ b/morpho-checkpoint-node/src/Morpho/Config/Orphans.hs
@@ -1,8 +1,5 @@
 {-# LANGUAGE ConstraintKinds #-}
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE StandaloneDeriving #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Morpho.Config.Orphans where

--- a/morpho-checkpoint-node/src/Morpho/Config/Types.hs
+++ b/morpho-checkpoint-node/src/Morpho/Config/Types.hs
@@ -1,7 +1,5 @@
-{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE GeneralisedNewtypeDeriving #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeOperators #-}
@@ -33,7 +31,6 @@ import Data.Aeson
 import Data.Functor.Compose
 import qualified Data.IP as IP
 import qualified Data.Text as T
-import Data.Time ()
 import Morpho.Config.Orphans ()
 import Morpho.Crypto.ECDSASignature
 import Network.Socket

--- a/morpho-checkpoint-node/src/Morpho/Ledger/Serialise.hs
+++ b/morpho-checkpoint-node/src/Morpho/Ledger/Serialise.hs
@@ -1,6 +1,4 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE EmptyCase #-}
 {-# LANGUAGE FlexibleContexts #-}

--- a/morpho-checkpoint-node/src/Morpho/Tracing/Orphan/MorphoToJSONInstances.hs
+++ b/morpho-checkpoint-node/src/Morpho/Tracing/Orphan/MorphoToJSONInstances.hs
@@ -1,0 +1,219 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DerivingStrategies #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE PolyKinds #-}
+{-# LANGUAGE QuantifiedConstraints #-}
+{-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE UndecidableInstances #-}
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module Morpho.Tracing.Orphan.MorphoToJSONInstances where
+
+import Cardano.Crypto.DSIGN.Class
+import Cardano.Crypto.Hash.Class
+import Cardano.Prelude hiding (show)
+import Codec.CBOR.Write
+import Data.Aeson (Options (tagSingleConstructors, unwrapUnaryRecords), ToJSON (..), ToJSONKey, Value (..), defaultOptions, genericToJSON)
+import qualified Data.ByteString.Base16 as B16
+import qualified Morpho.Config.Topology as MT
+import Morpho.Crypto.ECDSASignature
+import Morpho.Ledger.Block
+import Morpho.Ledger.Serialise
+import Morpho.Ledger.SnapshotTimeTravel
+import Morpho.Ledger.State
+import Morpho.Ledger.Update
+import Morpho.Tracing.Orphan.ExternalToJSONInstances ()
+import Morpho.Tracing.Types
+import Ouroboros.Consensus.Block
+import Ouroboros.Consensus.HeaderValidation
+import Ouroboros.Consensus.Ledger.Extended
+import Ouroboros.Consensus.Ledger.Inspect
+import Ouroboros.Consensus.Mempool.API (TraceEventMempool (..))
+import Ouroboros.Consensus.MiniProtocol.ChainSync.Client
+  ( TraceChainSyncClientEvent (..),
+  )
+import Ouroboros.Consensus.MiniProtocol.ChainSync.Server (TraceChainSyncServerEvent (..))
+import Ouroboros.Consensus.MiniProtocol.LocalTxSubmission.Server (TraceLocalTxSubmissionServerEvent (..))
+import Ouroboros.Consensus.Node.Tracers (TraceForgeEvent (..))
+import Ouroboros.Consensus.Protocol.BFT
+import Ouroboros.Consensus.Storage.ChainDB hiding (InvalidBlock, getTipPoint)
+import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
+import qualified Ouroboros.Consensus.Storage.ChainDB.Impl.Types as ChainDB
+import qualified Ouroboros.Consensus.Storage.ImmutableDB.API as ImmutableDB
+import qualified Ouroboros.Consensus.Storage.ImmutableDB.Impl.Types as ImmutableDB
+import Ouroboros.Consensus.Storage.LedgerDB.OnDisk
+import qualified Ouroboros.Consensus.Storage.LedgerDB.OnDisk as LedgerDB
+import Ouroboros.Consensus.Storage.Serialisation
+import qualified Ouroboros.Consensus.Storage.VolatileDB.Impl.Types as VolatileDB
+import qualified Ouroboros.Network.AnchoredFragment as AF
+import Ouroboros.Network.Block (Tip)
+import Ouroboros.Network.BlockFetch.ClientState
+
+jsonOptions :: Options
+jsonOptions =
+  defaultOptions
+    { tagSingleConstructors = True,
+      unwrapUnaryRecords = True
+    }
+
+instance ToJSON MorphoInitTrace where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON (TraceLocalTxSubmissionServerEvent (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON (LedgerEvent (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON (RealPoint (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance (BftCrypto c, HashAlgorithm h) => ToJSON (TraceReplayEvent (MorphoBlock h c) (Point (MorphoBlock h c))) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON (VolatileDB.ParseError (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON (VolatileDB.TraceEvent (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON (ImmutableDB.Tip (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON (ChainHash (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance (BftCrypto c, HashAlgorithm h) => ToJSON (ImmutableDB.ChunkFileError (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance (BftCrypto c, HashAlgorithm h) => ToJSON (ImmutableDB.TraceEvent (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON (LedgerDB.TraceEvent (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON (InitFailure (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance (BftCrypto c, HashAlgorithm h) => ToJSON (StreamFrom (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON (StreamTo (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance (BftCrypto c, HashAlgorithm h) => ToJSON (UnknownRange (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance (BftCrypto c, HashAlgorithm h) => ToJSON (ChainDB.TraceIteratorEvent (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance (BftCrypto c, HashAlgorithm h) => ToJSON (TraceOpenEvent (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON (Tip (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON (HeaderEnvelopeError (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance (BftCrypto c, HashAlgorithm h) => ToJSON (TraceChainSyncClientEvent (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance (BftCrypto c, HashAlgorithm h) => ToJSON (TraceFetchClientState (Header (MorphoBlock h c))) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON (GenTx (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON (TraceEventMempool (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance BftCrypto c => ToJSON (MorphoBlock h c) where
+  toJSON = genericToJSON jsonOptions
+
+instance BftCrypto c => ToJSON (BftFields c (MorphoBlock h c)) where
+  toJSON (BftFields x) = String $ decodeUtf8 $ B16.encode $ toStrictByteString $ encodeSignedDSIGN x
+
+instance (MorphoStateDefaultConstraints h c, Signable (BftDSIGN c) (MorphoStdHeader h c)) => ToJSON (ExtValidationError (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance (MorphoStateDefaultConstraints h c, Signable (BftDSIGN c) (MorphoStdHeader h c), HashAlgorithm h, BftCrypto c, ToJSON (Header (MorphoBlock h c))) => ToJSON (TraceValidationEvent (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON (MorphoStdHeader h c) where
+  toJSON = genericToJSON jsonOptions
+
+instance BftCrypto c => ToJSON (Header (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance (MorphoStateDefaultConstraints h c, Signable (BftDSIGN c) (MorphoStdHeader h c), BftCrypto c, HashAlgorithm h) => ToJSON (TraceInitChainSelEvent (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON (TraceGCEvent (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance (BftCrypto c, HashAlgorithm h) => ToJSON (TraceCopyToImmutableDBEvent (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance (BftCrypto c, HashAlgorithm h) => ToJSON (ChainDB.FollowerRollState (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance (BftCrypto c, HashAlgorithm h) => ToJSON (TraceFollowerEvent (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance (MorphoStateDefaultConstraints h c, Signable (BftDSIGN c) (MorphoStdHeader h c)) => ToJSON (InvalidBlockReason (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON (HeaderFields (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance (MorphoStateDefaultConstraints h c, Signable (BftDSIGN c) (MorphoStdHeader h c), BftCrypto c, HashAlgorithm h) => ToJSON (TraceAddBlockEvent (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance (MorphoStateDefaultConstraints h c, Signable (BftDSIGN c) (MorphoStdHeader h c), BftCrypto c, HashAlgorithm h) => ToJSON (ChainDB.TraceEvent (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance (BftCrypto c, HashAlgorithm h) => ToJSON (MorphoState (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance (BftCrypto c, HashAlgorithm h) => ToJSON (TimeTravelError (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON MorphoBlockTx where
+  toJSON = genericToJSON jsonOptions
+
+instance (BftCrypto c, HashAlgorithm h) => ToJSON (WontPushCheckpoint (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance (BftCrypto c, HashAlgorithm h) => ToJSON (ExtractStateTrace h c) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON (MorphoError (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON MorphoBody where
+  toJSON = genericToJSON jsonOptions
+
+instance (MorphoStateDefaultConstraints h c, Signable (BftDSIGN c) (MorphoStdHeader h c)) => ToJSON (TraceForgeEvent (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance BftCrypto c => ToJSON (BftFields c (MorphoStdHeader h c)) where
+  toJSON (BftFields x) = String $ decodeUtf8 $ B16.encode $ toStrictByteString $ encodeSignedDSIGN x
+
+instance BftCrypto c => ToJSON (SerialisedHeader (MorphoBlock h c)) where
+  toJSON (SerialisedHeaderFromDepPair (GenDepPair (NestedCtxt CtxtMorpho) b)) = toJSON b
+
+instance (BftCrypto c, HashAlgorithm h) => ToJSON (TraceChainSyncServerEvent (MorphoBlock h c)) where
+  toJSON = genericToJSON jsonOptions
+
+instance (BftCrypto c, HashAlgorithm h, ToJSON a) => ToJSON (AF.ChainUpdate (MorphoBlock h c) a) where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSON PublicKey where
+  toJSON = genericToJSON jsonOptions
+
+instance ToJSONKey PublicKey
+
+instance ToJSON MT.RemoteAddress where
+  toJSON = genericToJSON jsonOptions

--- a/morpho-checkpoint-node/src/Morpho/Tracing/Orphan/TracingInstances.hs
+++ b/morpho-checkpoint-node/src/Morpho/Tracing/Orphan/TracingInstances.hs
@@ -6,7 +6,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Morpho.Tracing.TracingOrphanInstances where
+module Morpho.Tracing.Orphan.TracingInstances where
 
 import Cardano.BM.Tracing
   ( HasPrivacyAnnotation (..),
@@ -15,11 +15,10 @@ import Cardano.BM.Tracing
   )
 import Cardano.Prelude hiding (show)
 import Morpho.Ledger.Block
-import Morpho.Ledger.Serialise ()
 import Morpho.Ledger.SnapshotTimeTravel
 import Morpho.Ledger.State
 import Morpho.RPC.Abstract
-import Morpho.Tracing.OrphanToJSONInstances ()
+import Morpho.Tracing.Orphan.MorphoToJSONInstances ()
 import Morpho.Tracing.Types
 import Network.Mux (MuxTrace (..), WithMuxBearer (..))
 import qualified Network.Socket as Socket (SockAddr)
@@ -45,7 +44,6 @@ import qualified Ouroboros.Consensus.Storage.ChainDB as ChainDB
 import qualified Ouroboros.Consensus.Storage.ImmutableDB.Impl.Types as ImmutableDB
 import qualified Ouroboros.Consensus.Storage.LedgerDB.OnDisk as LedgerDB
 import qualified Ouroboros.Consensus.Storage.VolatileDB.Impl.Types as VolatileDB
-import Ouroboros.Consensus.Util.Orphans ()
 import Ouroboros.Network.Block
 import Ouroboros.Network.BlockFetch.ClientState
   ( TraceFetchClientState (..),

--- a/morpho-checkpoint-node/src/Morpho/Tracing/Tracers.hs
+++ b/morpho-checkpoint-node/src/Morpho/Tracing/Tracers.hs
@@ -28,10 +28,9 @@ import Morpho.Config.Types
 import Morpho.Ledger.Block
 import Morpho.Ledger.SnapshotTimeTravel
 import Morpho.Ledger.Update
-import Morpho.Node.RunNode ()
 import Morpho.RPC.Abstract
+import Morpho.Tracing.Orphan.TracingInstances ()
 import Morpho.Tracing.Pretty (MPretty (..))
-import Morpho.Tracing.TracingOrphanInstances ()
 import Morpho.Tracing.Types
 import Morpho.Tracing.Verbosity
 import Network.Mux.Trace (MuxTrace (..), WithMuxBearer (..))

--- a/morpho-checkpoint-node/tests/Test/Morpho/Examples.hs
+++ b/morpho-checkpoint-node/tests/Test/Morpho/Examples.hs
@@ -28,7 +28,6 @@ import Morpho.Config.Types
 import Morpho.Crypto.ECDSASignature
 import Morpho.Ledger.Block
 import Morpho.Ledger.PowTypes
-import Morpho.Ledger.Serialise ()
 import Morpho.Ledger.State
 import Morpho.Ledger.Tx
 import Morpho.Ledger.Update

--- a/morpho-checkpoint-node/tests/Test/Morpho/QSM.hs
+++ b/morpho-checkpoint-node/tests/Test/Morpho/QSM.hs
@@ -39,7 +39,6 @@ import Test.Morpho.MockRpc
 import Test.QuickCheck
 import Test.QuickCheck.Monadic (monadicIO)
 import Test.StateMachine
-import Test.StateMachine.Sequential ()
 import qualified Test.StateMachine.Types.Rank2 as Rank2
 import Test.StateMachine.Utils
 import Test.Tasty

--- a/morpho-checkpoint-node/tests/Test/Morpho/Serialisation.hs
+++ b/morpho-checkpoint-node/tests/Test/Morpho/Serialisation.hs
@@ -19,7 +19,6 @@ import Ouroboros.Consensus.Util (Dict (..))
 import Test.Morpho.Generators
 import Test.Tasty
 import Test.Tasty.QuickCheck
-import Test.Util.Orphans.Arbitrary ()
 import Test.Util.Serialisation.Roundtrip
 
 serialiseTests :: TestTree

--- a/morpho-checkpoint-node/tests/Test/Morpho/Tracing.hs
+++ b/morpho-checkpoint-node/tests/Test/Morpho/Tracing.hs
@@ -1,6 +1,3 @@
-{-# LANGUAGE DeriveAnyClass #-}
-{-# LANGUAGE DeriveGeneric #-}
-
 module Test.Morpho.Tracing (traceTests) where
 
 import Cardano.Prelude


### PR DESCRIPTION
Restructured files for orphan instances related to ToJSONInstances. Also removed unused imports of orphan instances from other modules.